### PR TITLE
feat: implement show_string using relations

### DIFF
--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -27,7 +27,7 @@ class ConversionOptions:
 
         self.return_names_with_types = False
 
-        self.implement_show_string = False
+        self.implement_show_string = True
 
         self.backend = backend
 

--- a/src/gateway/converter/label_relations.py
+++ b/src/gateway/converter/label_relations.py
@@ -55,7 +55,7 @@ def get_common_section(rel: algebra_pb2.Rel) -> algebra_pb2.RelCommon:
             result = rel.expand.common
         case _:
             raise NotImplementedError('Finding the common section for type '
-                                      f'{rel.WhichOneof('rel_type')} is not implemented')
+                                      f'{rel.WhichOneof("rel_type")} is not implemented')
     return result
 
 

--- a/src/gateway/converter/simplify_casts.py
+++ b/src/gateway/converter/simplify_casts.py
@@ -60,7 +60,7 @@ class SimplifyCasts(SubstraitPlanVisitor):
                 return rel.extension_single.input
             case _:
                 raise NotImplementedError('Finding single inputs of relations with type '
-                                          f'{rel.WhichOneof('rel_type')} are not implemented')
+                                          f'{rel.WhichOneof("rel_type")} are not implemented')
 
     @staticmethod
     def replace_single_input(rel: algebra_pb2.Rel, new_input: algebra_pb2.Rel):
@@ -80,7 +80,7 @@ class SimplifyCasts(SubstraitPlanVisitor):
                 rel.extension_single.input.CopyFrom(new_input)
             case _:
                 raise NotImplementedError('Modifying inputs of relations with type '
-                                          f'{rel.WhichOneof('rel_type')} are not implemented')
+                                          f'{rel.WhichOneof("rel_type")} are not implemented')
 
     def update_field_references(self, plan_id: int) -> None:
         """Uses the field references using the specified portion of the plan."""

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -40,6 +40,18 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_comparison.yaml', 'equal:str_str', type_pb2.Type(
             bool=type_pb2.Type.Boolean(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '>=': ExtensionFunction(
+        '/functions_comparison.yaml', 'gte:str_str', type_pb2.Type(
+            bool=type_pb2.Type.Boolean(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '>': ExtensionFunction(
+        '/functions_comparison.yaml', 'gt:str_str', type_pb2.Type(
+            bool=type_pb2.Type.Boolean(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    '-': ExtensionFunction(
+        '/functions_arithmetic.yaml', 'subtract:i64_i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'array_contains': ExtensionFunction(
         '/functions_set.yaml', 'index_in:str_list<str>', type_pb2.Type(
             bool=type_pb2.Type.Boolean(
@@ -59,6 +71,38 @@ SPARK_SUBSTRAIT_MAPPING = {
     'length': ExtensionFunction(
         '/functions_string.yaml', 'char_length:str', type_pb2.Type(
             i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'max': ExtensionFunction(
+        '/functions_aggregate.yaml', 'max:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'string_agg': ExtensionFunction(
+        '/functions_string.yaml', 'string_agg:str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'least': ExtensionFunction(
+        '/functions_comparison.yaml', 'least:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'greatest': ExtensionFunction(
+        '/functions_comparison.yaml', 'greatest:i64', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'concat': ExtensionFunction(
+        '/functions_string.yaml', 'concat:str_str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'repeat': ExtensionFunction(
+        '/functions_string.yaml', 'repeat:str_i64', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'lpad': ExtensionFunction(
+        '/functions_string.yaml', 'lpad:str_i64_str', type_pb2.Type(
+            string=type_pb2.Type.String(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'rpad': ExtensionFunction(
+        '/functions_string.yaml', 'rpad:str_i64_str', type_pb2.Type(
+            string=type_pb2.Type.String(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'count': ExtensionFunction(
         '/functions_aggregate_generic.yaml', 'count:any', type_pb2.Type(

--- a/src/gateway/converter/spark_to_substrait_test.py
+++ b/src/gateway/converter/spark_to_substrait_test.py
@@ -41,7 +41,9 @@ def test_plan_conversion(request, path):
         splan_prototext = file.read()
     substrait_plan = text_format.Parse(splan_prototext, plan_pb2.Plan())
 
-    convert = SparkSubstraitConverter(duck_db())
+    options = duck_db()
+    options.implement_show_string = False
+    convert = SparkSubstraitConverter(options)
     substrait = convert.convert_plan(spark_plan)
 
     if request.config.getoption('rebuild_goldens'):

--- a/src/gateway/converter/substrait_builder.py
+++ b/src/gateway/converter/substrait_builder.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Convenience builder for constructing Substrait plans."""
+import itertools
+from typing import List, Any
+
+from substrait.gen.proto import algebra_pb2, type_pb2
+
+from gateway.converter.spark_functions import ExtensionFunction
+
+
+def flatten(list_of_lists: List[List[Any]]) -> List[Any]:
+    """Flattens a list of lists into a list."""
+    return list(itertools.chain.from_iterable(list_of_lists))
+
+
+# pylint: disable=E1101
+
+def fetch_relation(input_relation: algebra_pb2.Rel, num_rows: int) -> algebra_pb2.Rel:
+    """Constructs a Substrait fetch plan node."""
+    fetch = algebra_pb2.Rel(fetch=algebra_pb2.FetchRel(input=input_relation, count=num_rows))
+
+    return fetch
+
+
+def project_relation(input_relation: algebra_pb2.Rel,
+                     expressions: List[algebra_pb2.Expression]) -> algebra_pb2.Rel:
+    """Constructs a Substrait project plan node."""
+    return algebra_pb2.Rel(
+        project=algebra_pb2.ProjectRel(input=input_relation, expressions=expressions))
+
+
+# pylint: disable=fixme
+def aggregate_relation(input_relation: algebra_pb2.Rel,
+                       measures: List[algebra_pb2.AggregateFunction]) -> algebra_pb2.Rel:
+    """Constructs a Substrait aggregate plan node."""
+    aggregate = algebra_pb2.Rel(
+        aggregate=algebra_pb2.AggregateRel(
+            common=algebra_pb2.RelCommon(emit=algebra_pb2.RelCommon.Emit(
+                output_mapping=range(len(measures)))),
+            input=input_relation))
+    # TODO -- Add support for groupings.
+    for measure in measures:
+        aggregate.aggregate.measures.append(
+            algebra_pb2.AggregateRel.Measure(measure=measure))
+    return aggregate
+
+
+def join_relation(left: algebra_pb2.Rel, right: algebra_pb2.Rel) -> algebra_pb2.Rel:
+    """Constructs a Substrait join plan node."""
+    return algebra_pb2.Rel(
+        join=algebra_pb2.JoinRel(common=algebra_pb2.RelCommon(), left=left, right=right,
+                                 expression=algebra_pb2.Expression(
+                                     literal=algebra_pb2.Expression.Literal(boolean=True)),
+                                 type=algebra_pb2.JoinRel.JoinType.JOIN_TYPE_INNER))
+
+
+def concat(function_info: ExtensionFunction,
+           expressions: List[algebra_pb2.Expression]) -> algebra_pb2.Expression:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(
+        scalar_function=algebra_pb2.Expression.ScalarFunction(
+            function_reference=function_info.anchor,
+            output_type=function_info.output_type,
+            arguments=[algebra_pb2.FunctionArgument(value=expression) for expression in expressions]
+        ))
+
+
+def strlen(function_info: ExtensionFunction,
+           expression: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(
+        scalar_function=algebra_pb2.Expression.ScalarFunction(
+            function_reference=function_info.anchor,
+            output_type=function_info.output_type,
+            arguments=[algebra_pb2.FunctionArgument(value=expression)]))
+
+
+def cast_operation(expression: algebra_pb2.Expression,
+                   output_type: type_pb2.Type) -> algebra_pb2.Expression:
+    """Constructs a Substrait cast expression."""
+    return algebra_pb2.Expression(
+        cast=algebra_pb2.Expression.Cast(input=expression, type=output_type)
+    )
+
+
+def if_then_else_operation(if_expr: algebra_pb2.Expression, then_expr: algebra_pb2.Expression,
+                           else_expr: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a simplistic Substrait if-then-else expression."""
+    return algebra_pb2.Expression(
+        if_then=algebra_pb2.Expression.IfThen(
+            **{'ifs': [
+                algebra_pb2.Expression.IfThen.IfClause(**{'if': if_expr, 'then': then_expr})],
+                'else': else_expr})
+    )
+
+
+def field_reference(field_number: int) -> algebra_pb2.Expression:
+    """Constructs a Substrait field reference expression."""
+    return algebra_pb2.Expression(
+        selection=algebra_pb2.Expression.FieldReference(
+            direct_reference=algebra_pb2.Expression.ReferenceSegment(
+                struct_field=algebra_pb2.Expression.ReferenceSegment.StructField(
+                    field=field_number))))
+
+
+def max_agg_function(function_info: ExtensionFunction,
+                     field_number: int) -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait max aggregate function."""
+    # TODO -- Reorganize all functions to belong to a class which determines the info.
+    return algebra_pb2.AggregateFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number))])
+
+
+def string_concat_agg_function(function_info: ExtensionFunction,
+                               field_number: int,
+                               separator: str = '') -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait string concat aggregate function."""
+    return algebra_pb2.AggregateFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=field_reference(field_number)),
+                   algebra_pb2.FunctionArgument(value=string_literal(separator))])
+
+
+def least_function(function_info: ExtensionFunction,
+                   expr1: algebra_pb2.Expression,
+                   expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def greatest_function(function_info: ExtensionFunction,
+                      expr1: algebra_pb2.Expression,
+                      expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def greater_or_equal_function(function_info: ExtensionFunction,
+                              expr1: algebra_pb2.Expression,
+                              expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def greater_function(function_info: ExtensionFunction,
+                     expr1: algebra_pb2.Expression,
+                     expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def minus_function(function_info: ExtensionFunction,
+                   expr1: algebra_pb2.Expression,
+                   expr2: algebra_pb2.Expression) -> algebra_pb2.Expression:
+    """Constructs a Substrait min expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=expr1),
+                   algebra_pb2.FunctionArgument(value=expr2)]))
+
+
+def repeat_function(function_info: ExtensionFunction,
+                    string: str,
+                    count: algebra_pb2.Expression) -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[algebra_pb2.FunctionArgument(value=string_literal(string)),
+                   algebra_pb2.FunctionArgument(value=count)]))
+
+
+def lpad_function(function_info: ExtensionFunction,
+                  expression: algebra_pb2.Expression, count: algebra_pb2.Expression,
+                  pad_string: str = ' ') -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[
+            algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
+            algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
+            algebra_pb2.FunctionArgument(
+                value=cast_operation(string_literal(pad_string), varchar_type()))]))
+
+
+def rpad_function(function_info: ExtensionFunction,
+                  expression: algebra_pb2.Expression, count: algebra_pb2.Expression,
+                  pad_string: str = ' ') -> algebra_pb2.AggregateFunction:
+    """Constructs a Substrait concat expression."""
+    return algebra_pb2.Expression(scalar_function=
+    algebra_pb2.Expression.ScalarFunction(
+        function_reference=function_info.anchor,
+        output_type=function_info.output_type,
+        arguments=[
+            algebra_pb2.FunctionArgument(value=cast_operation(expression, varchar_type())),
+            algebra_pb2.FunctionArgument(value=cast_operation(count, integer_type())),
+            algebra_pb2.FunctionArgument(
+                value=cast_operation(string_literal(pad_string), varchar_type()))]))
+
+
+def string_literal(val: str) -> algebra_pb2.Expression:
+    """Constructs a Substrait string literal expression."""
+    return algebra_pb2.Expression(literal=algebra_pb2.Expression.Literal(string=val))
+
+
+def bigint_literal(val: int) -> algebra_pb2.Expression:
+    """Constructs a Substrait string literal expression."""
+    return algebra_pb2.Expression(literal=algebra_pb2.Expression.Literal(i64=val))
+
+
+def string_type(required: bool = True) -> type_pb2.Type:
+    """Constructs a Substrait string type."""
+    if required:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED
+    else:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_NULLABLE
+    return type_pb2.Type(string=type_pb2.Type.String(nullability=nullability))
+
+
+def varchar_type(required: bool = True) -> type_pb2.Type:
+    """Constructs a Substrait varchar type."""
+    if required:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED
+    else:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_NULLABLE
+    return type_pb2.Type(varchar=type_pb2.Type.VarChar(nullability=nullability))
+
+
+def integer_type(required: bool = True) -> type_pb2.Type:
+    """Constructs a Substrait i32 type."""
+    if required:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_REQUIRED
+    else:
+        nullability = type_pb2.Type.Nullability.NULLABILITY_NULLABLE
+    return type_pb2.Type(i32=type_pb2.Type.I32(nullability=nullability))

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -9,6 +9,7 @@ import grpc
 import pyarrow
 import pyspark.sql.connect.proto.base_pb2_grpc as pb2_grpc
 import pyspark.sql.connect.proto.base_pb2 as pb2
+from pyspark.sql.connect.proto import types_pb2
 
 from gateway.converter.conversion_options import duck_db, datafusion
 from gateway.converter.spark_to_substrait import SparkSubstraitConverter
@@ -42,6 +43,27 @@ def batch_to_bytes(batch: pyarrow.RecordBatch, schema: pyarrow.Schema) -> bytes:
     return buffer.getvalue()
 
 
+# pylint: disable=E1101
+def convert_pyarrow_schema_to_spark(schema: pyarrow.Schema) -> types_pb2.DataType:
+    """Converts a PyArrow schema to a SparkConnect DataType.Struct schema."""
+    fields = []
+    for field in schema:
+        if field.type == pyarrow.bool_():
+            data_type = types_pb2.DataType(boolean=types_pb2.DataType.Boolean())
+        elif field.type == pyarrow.int64():
+            data_type = types_pb2.DataType(long=types_pb2.DataType.Long())
+        elif field.type == pyarrow.string():
+            data_type = types_pb2.DataType(string=types_pb2.DataType.String())
+        else:
+            raise ValueError(
+                f'Unsupported arrow schema to Spark schema conversion type: {field.type}')
+
+        struct_field = types_pb2.DataType.StructField(name=field.name, data_type=data_type)
+        fields.append(struct_field)
+
+    return types_pb2.DataType(struct=types_pb2.DataType.Struct(fields=fields))
+
+
 # pylint: disable=E1101,fixme
 class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
     """Provides the SparkConnect service."""
@@ -72,15 +94,25 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
                 'rel_type') == 'show_string':
             yield pb2.ExecutePlanResponse(
                 session_id=request.session_id,
-                arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(row_count=results.num_rows,
-                                                               data=show_string(results)))
+                arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(
+                    row_count=results.num_rows,
+                    data=show_string(results)),
+                schema=types_pb2.DataType(struct=types_pb2.DataType.Struct(
+                    fields=[types_pb2.DataType.StructField(
+                        name='show_string',
+                        data_type=types_pb2.DataType(string=types_pb2.DataType.String()))]
+                )),
+            )
             return
 
         for batch in results.to_batches():
-            yield pb2.ExecutePlanResponse(session_id=request.session_id,
-                                          arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(
-                                              row_count=batch.num_rows,
-                                              data=batch_to_bytes(batch, results.schema)))
+            yield pb2.ExecutePlanResponse(
+                session_id=request.session_id,
+                arrow_batch=pb2.ExecutePlanResponse.ArrowBatch(
+                    row_count=batch.num_rows,
+                    data=batch_to_bytes(batch, results.schema)),
+                schema=convert_pyarrow_schema_to_spark(results.schema),
+            )
         # TODO -- When spark 3.4.0 support is not required, yield a ResultComplete message here.
 
     def AnalyzePlan(self, request, context):


### PR DESCRIPTION
While writing this is was evident that writing generated protobufs even with list comprehensions
were going to be nigh near impossible to read. I introduced the start of a substrait_builder class
which allows for an easier way of constructing relations and generally allows for composability of
sections using functions. It doesn't implement all functions, has some repetition that could be
eliminated (for instance how many methods do we need that take two expressions as arguments?),
and could be even cleaner if every function usage didn't need to pass in the function information.
However addressing those issues are beyond the scope of what we were trying to accomplish here.
The builder really belongs in substrait-python and doing so will require refactoring how functions
are converted from spark names into Substrait. After that the other code already in
spark_to_substrait.py can be updated to use the builder which will also make it more readable.