### PR TITLE
fix: datafusion doesn't have any_value

### DIFF
--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -17,6 +17,7 @@ class ConversionOptions:
         self.use_emits_instead_of_direct = False
         self.use_switch_expressions_where_possible = True
         self.use_duckdb_regexp_matches_function = False
+        self.use_first_value_function = False
         self.use_regexp_like_function = False
         self.duckdb_project_emit_workaround = False
         self.safety_project_read_relations = False
@@ -43,6 +44,7 @@ def datafusion():
     options = ConversionOptions(backend=BackendOptions(BackendEngine.DATAFUSION))
     options.use_switch_expressions_where_possible = False
     options.use_regexp_like_function = True
+    options.use_first_value_function = True
     return options
 
 

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -17,7 +17,7 @@ class ConversionOptions:
         self.use_emits_instead_of_direct = False
         self.use_switch_expressions_where_possible = True
         self.use_duckdb_regexp_matches_function = False
-        self.use_first_value_function = False
+        self.use_first_value_as_any_value = False
         self.use_regexp_like_function = False
         self.duckdb_project_emit_workaround = False
         self.safety_project_read_relations = False
@@ -44,7 +44,7 @@ def datafusion():
     options = ConversionOptions(backend=BackendOptions(BackendEngine.DATAFUSION))
     options.use_switch_expressions_where_possible = False
     options.use_regexp_like_function = True
-    options.use_first_value_function = True
+    options.use_first_value_as_any_value = True
     return options
 
 

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -180,6 +180,10 @@ SPARK_SUBSTRAIT_MAPPING = {
         '/functions_aggregate_generic.yaml', 'any_value:any', type_pb2.Type(
             i64=type_pb2.Type.I64(
                 nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
+    'first_value': ExtensionFunction(
+        '/functions_aggregate_generic.yaml', 'first_value:any', type_pb2.Type(
+            i64=type_pb2.Type.I64(
+                nullability=type_pb2.Type.Nullability.NULLABILITY_REQUIRED))),
     'and': ExtensionFunction(
         '/functions_boolean.yaml', 'and:bool_bool', type_pb2.Type(
             bool=type_pb2.Type.Boolean(

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1127,7 +1127,10 @@ class SparkSubstraitConverter:
 
     def convert_deduplicate_relation(self, rel: spark_relations_pb2.Deduplicate) -> algebra_pb2.Rel:
         """Convert a Spark deduplicate relation into a Substrait aggregation."""
-        any_value_func = self.lookup_function_by_name('any_value')
+        if self._conversion_options.use_first_value_function:
+            any_value_func = self.lookup_function_by_name('first_value')
+        else:
+            any_value_func = self.lookup_function_by_name('any_value')
 
         aggregate = algebra_pb2.AggregateRel(input=self.convert_relation(rel.input))
         self.update_field_references(rel.input.common.plan_id)

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1127,7 +1127,7 @@ class SparkSubstraitConverter:
 
     def convert_deduplicate_relation(self, rel: spark_relations_pb2.Deduplicate) -> algebra_pb2.Rel:
         """Convert a Spark deduplicate relation into a Substrait aggregation."""
-        if self._conversion_options.use_first_value_function:
+        if self._conversion_options.use_first_value_as_any_value:
             any_value_func = self.lookup_function_by_name('first_value')
         else:
             any_value_func = self.lookup_function_by_name('any_value')

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -26,9 +26,6 @@ def mark_tests_as_xfail(request):
             request.node.add_marker(pytest.mark.xfail(reason='Results mismatch'))
         elif originalname in ['test_query_03', 'test_query_10', 'test_query_20']:
             request.node.add_marker(pytest.mark.xfail(reason='Schema mismatch'))
-        elif originalname in ['test_query_04']:
-            request.node.add_marker(pytest.mark.xfail(
-                reason='Aggregated function any_value is not supported'))
         elif originalname in ['test_query_07']:
             request.node.add_marker(pytest.mark.xfail(reason='Duplicate Expression names'))
         elif originalname in ['test_query_09']:


### PR DESCRIPTION
datafusion does not have an any_value function.

for query 4, we can use first_value without any ordering since it will behave similarly:
https://substrait.io/extensions/functions_aggregate_generic/#any_value
https://datafusion.apache.org/user-guide/sql/aggregate_functions.html#first-value