### PR TITLE
feat: add tests for astype and name

### DIFF
--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1296,9 +1296,7 @@ class SparkSubstraitConverter:
         """Convert a Spark subquery alias relation into a Substrait relation."""
         result = self.convert_relation(rel.input)
         self.update_field_references(rel.input.common.plan_id)
-        symbol = self._symbol_table.get_symbol(self._current_plan_id)
-        symbol.output_fields[-1] = rel.alias
-        return result
+        raise NotImplementedError('Subquery alias relations are not yet implemented')
 
     def convert_deduplicate_relation(self, rel: spark_relations_pb2.Deduplicate) -> algebra_pb2.Rel:
         """Convert a Spark deduplicate relation into a Substrait aggregation."""

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1294,8 +1294,6 @@ class SparkSubstraitConverter:
     def convert_subquery_alias_relation(self,
                                         rel: spark_relations_pb2.SubqueryAlias) -> algebra_pb2.Rel:
         """Convert a Spark subquery alias relation into a Substrait relation."""
-        result = self.convert_relation(rel.input)
-        self.update_field_references(rel.input.common.plan_id)
         raise NotImplementedError('Subquery alias relations are not yet implemented')
 
     def convert_deduplicate_relation(self, rel: spark_relations_pb2.Deduplicate) -> algebra_pb2.Rel:

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -126,10 +126,6 @@ only showing top 1 row
         assert list(outcome[0].asDict().keys()) == ['foo']
 
     def test_subquery_alias(self, users_dataframe):
-        expected = [
-            Row(user_id='user849118289'),
-        ]
-
         with pytest.raises(Exception) as exc_info:
             users_dataframe.select(col('user_id')).alias('foo').limit(1).collect()
 

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -20,9 +20,11 @@ def mark_dataframe_tests_as_xfail(request):
         pytest.importorskip("datafusion.substrait")
         if originalname in ['test_column_getfield', 'test_column_getitem']:
             request.node.add_marker(pytest.mark.xfail(reason='structs not handled'))
-    if originalname == 'test_column_getitem':
+    elif originalname == 'test_column_getitem':
         request.node.add_marker(pytest.mark.xfail(reason='maps and lists not handled'))
-
+    elif source == 'spark':
+        if originalname == 'test_subquery_alias':
+            pytest.xfail('Subquery alias relations are not yet implemented (so no exception)')
 
 # pylint: disable=missing-function-docstring
 # ruff: noqa: E712

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -219,6 +219,9 @@ only showing top 1 row
 
         with utilizes_valid_plans(df):
             outcome = df.select(df.l.getItem(0), df.d.getItem("key")).collect()
+
+        assertDataFrameEqual(outcome, expected)
+
     def test_astype(self, users_dataframe):
         expected = [
             Row(user_id=849, name='Brooke Jones', paid_for_service=False),

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -114,6 +114,38 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    def test_alias(self, users_dataframe):
+        expected = [
+            Row(foo='user849118289'),
+        ]
+
+        with utilizes_valid_plans(users_dataframe):
+            outcome = users_dataframe.select(col('user_id').alias('foo')).limit(1).collect()
+
+        assertDataFrameEqual(outcome, expected)
+        assert list(outcome[0].asDict().keys()) == ['foo']
+
+    def test_subquery_alias(self, users_dataframe):
+        expected = [
+            Row(user_id='user849118289'),
+        ]
+
+        with pytest.raises(Exception) as exc_info:
+            users_dataframe.select(col('user_id')).alias('foo').limit(1).collect()
+
+        assert exc_info.match('Subquery alias relations are not yet implemented')
+
+    def test_name(self, users_dataframe):
+        expected = [
+            Row(foo='user849118289'),
+        ]
+
+        with utilizes_valid_plans(users_dataframe):
+            outcome = users_dataframe.select(col('user_id').name('foo')).limit(1).collect()
+
+        assertDataFrameEqual(outcome, expected)
+        assert list(outcome[0].asDict().keys()) == ['foo']
+
     def test_cast(self, users_dataframe):
         expected = [
             Row(user_id=849, name='Brooke Jones', paid_for_service=False),
@@ -189,6 +221,15 @@ only showing top 1 row
 
         with utilizes_valid_plans(df):
             outcome = df.select(df.l.getItem(0), df.d.getItem("key")).collect()
+    def test_astype(self, users_dataframe):
+        expected = [
+            Row(user_id=849, name='Brooke Jones', paid_for_service=False),
+        ]
+
+        with utilizes_valid_plans(users_dataframe):
+            outcome = users_dataframe.withColumn(
+                'user_id',
+                substring(col('user_id'), 5, 3).astype('integer')).limit(1).collect()
 
         assertDataFrameEqual(outcome, expected)
 

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -22,11 +22,8 @@ def mark_dataframe_tests_as_xfail(request):
             request.node.add_marker(pytest.mark.xfail(reason='structs not handled'))
     elif originalname == 'test_column_getitem':
         request.node.add_marker(pytest.mark.xfail(reason='maps and lists not handled'))
-    elif source == 'spark':
-        if originalname == 'test_subquery_alias':
-            pytest.xfail('Subquery alias relations are not yet implemented (so no exception)')
     elif source == 'spark' and originalname == 'test_subquery_alias':
-        pytest.xfail('Subquery alias relations are not yet implemented (so no exception)')
+        pytest.xfail('Spark supports subquery_alias but everyone else does not')
 
 
 # pylint: disable=missing-function-docstring

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -25,6 +25,9 @@ def mark_dataframe_tests_as_xfail(request):
     elif source == 'spark':
         if originalname == 'test_subquery_alias':
             pytest.xfail('Subquery alias relations are not yet implemented (so no exception)')
+    elif source == 'spark' and originalname == 'test_subquery_alias':
+        pytest.xfail('Subquery alias relations are not yet implemented (so no exception)')
+
 
 # pylint: disable=missing-function-docstring
 # ruff: noqa: E712

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -226,7 +226,7 @@ class TestTpchWithDataFrameAPI:
                                       (col('l_discount') >= 0.05) &
                                       (col('l_discount') <= 0.07) &
                                       (col('l_quantity') < 24)).agg(
-                try_sum(col('l_extendedprice') * col('l_discount'))).alias('revenue').collect()
+                try_sum(col('l_extendedprice') * col('l_discount')).alias('revenue')).collect()
 
         assert_dataframes_equal(outcome, expected)
 
@@ -485,8 +485,7 @@ class TestTpchWithDataFrameAPI:
                                 (col('l_shipdate') < '1995-10-01')).select(
                 'p_type', (col('l_extendedprice') * (1 - col('l_discount'))).alias('value')).agg(
                 try_sum(when(col('p_type').contains('PROMO'), col('value'))) * 100 / try_sum(
-                    col('value'))
-            ).alias('promo_revenue').collect()
+                    col('value')).alias('promo_revenue')).collect()
 
         assert_dataframes_equal(outcome, expected)
 
@@ -562,7 +561,7 @@ class TestTpchWithDataFrameAPI:
                 col('p_partkey').alias('key'), 'avg_quantity').join(
                 fpart, col('key') == fpart.p_partkey).filter(
                 col('l_quantity') < col('avg_quantity')).agg(
-                try_sum('l_extendedprice') / 7).alias('avg_yearly').collect()
+                (try_sum('l_extendedprice') / 7).alias('avg_yearly')).collect()
 
         assert_dataframes_equal(outcome, expected)
 

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -591,7 +591,7 @@ class TestTpchWithDataFrameAPI:
                 'l_quantity', 'c_name', 'c_custkey', 'o_orderkey', 'o_orderdate',
                 'o_totalprice').groupBy(
                 'c_name', 'c_custkey', 'o_orderkey', 'o_orderdate', 'o_totalprice').agg(
-                try_sum('l_quantity')).alias('sum_l_quantity')
+                try_sum('l_quantity').alias('sum_l_quantity'))
 
             sorted_outcome = outcome.sort(desc('o_totalprice'), 'o_orderdate').limit(2).collect()
 


### PR DESCRIPTION
This PR also changes subquery_alias to throw an error.  There were a few tests
which were erroneously using subquery_alias which should have been a column
alias which have been fixed.  It does not appear that subquery_alias has any
material effect on a Substrait plan.
