### PR TITLE
feat: add support for set operations

### DIFF
--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1326,7 +1326,8 @@ class SparkSubstraitConverter:
             project.project.common.emit.output_mapping.append(idx)
         return project
 
-    def convert_set_operation_relation(self, rel: spark_relations_pb2.SetOperation) -> algebra_pb2.Rel:
+    def convert_set_operation_relation(
+            self, rel: spark_relations_pb2.SetOperation) -> algebra_pb2.Rel:
         """Convert a Spark set operation relation into a Substrait set operation relation."""
         left = self.convert_relation(rel.left_input)
         right = self.convert_relation(rel.right_input)

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1334,17 +1334,22 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.left_input.common.plan_id)
         set_operation.common.CopyFrom(self.create_common_relation())
 
+        if rel.by_name:
+            # TODO -- Support by_name and allow_missing_columns.
+            raise NotImplementedError('Substrait cannot represent set operations by name')
         match rel.set_op_type:
             case spark_relations_pb2.SetOperation.SetOpType.SET_OP_TYPE_UNION:
-                # TODO -- Support by_name
-                # TODO -- Support allow_missing_columns
                 if rel.is_all:
                     operation = algebra_pb2.SetRel.SET_OP_UNION_ALL
                 else:
                     operation = algebra_pb2.SetRel.SET_OP_UNION_DISTINCT
             case spark_relations_pb2.SetOperation.SetOpType.SET_OP_TYPE_INTERSECT:
+                if rel.is_all:
+                    raise NotImplementedError('Substrait cannot represent INTERSECT ALL')
                 operation = algebra_pb2.SetRel.SET_OP_INTERSECTION_PRIMARY
             case spark_relations_pb2.SetOperation.SetOpType.SET_OP_TYPE_EXCEPT:
+                if rel.is_all:
+                    raise NotImplementedError('Substrait cannot represent MINUS ALL')
                 operation = algebra_pb2.SetRel.SET_OP_MINUS_PRIMARY
             case _:
                 raise ValueError(f'Unexpected set operation type: {rel.set_op_type}')

--- a/src/gateway/converter/substrait_plan_visitor.py
+++ b/src/gateway/converter/substrait_plan_visitor.py
@@ -772,6 +772,8 @@ class SubstraitPlanVisitor:
                 self.visit_exchange_relation(rel.exchange)
             case 'expand':
                 self.visit_expand_relation(rel.expand)
+            case 'set':
+                self.visit_set_relation(rel.set)
             case _:
                 raise ValueError(f'Unexpected rel type: {rel.WhichOneof("rel_type")}')
 

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pyspark
 import pytest
 from gateway.tests.conftest import find_tpch
 from gateway.tests.plan_validator import utilizes_valid_plans
 from hamcrest import assert_that, equal_to
-import pyarrow as pa
-import pyarrow.parquet as pq
-import pyspark
 from pyspark import Row
 from pyspark.sql.functions import col, substring
 from pyspark.testing import assertDataFrameEqual

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -211,10 +211,7 @@ only showing top 1 row
         struct_array = pa.array(data, type=struct_type)
         table = pa.Table.from_arrays([struct_array], names=['r'])
 
-        pq.write_table(table, 'test_table.parquet')
-        table_df = spark_session.read.parquet('test_table.parquet')
-        table_df.createOrReplaceTempView('mytesttable')
-        df = spark_session.table('mytesttable')
+        df = create_parquet_table(spark_session, 'mytesttable', table)
 
         with utilizes_valid_plans(df):
             outcome = df.select(df.r.getField("b"), df.r.a).collect()
@@ -231,10 +228,7 @@ only showing top 1 row
                              type=pa.map_(pa.string(), pa.string(), False))
         table = pa.Table.from_arrays([list_array, map_array], names=['l', 'd'])
 
-        pq.write_table(table, 'test_table.parquet')
-        table_df = spark_session.read.parquet('test_table.parquet')
-        table_df.createOrReplaceTempView('mytesttable')
-        df = spark_session.table('mytesttable')
+        df = create_parquet_table(spark_session, 'mytesttable', table)
 
         with utilizes_valid_plans(df):
             outcome = df.select(df.l.getItem(0), df.d.getItem("key")).collect()

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -41,9 +41,9 @@ def mark_dataframe_tests_as_xfail(request):
     if source == 'gateway-over-duckdb' and originalname in ['test_union', 'test_unionall']:
         request.node.add_marker(pytest.mark.xfail(reason='DuckDB treats all unions as distinct'))
     if source == 'gateway-over-datafusion' and originalname == 'test_subtract':
-        request.node.add_marker(pytest.mark.xfail(reason='subtract not supported"))
+        request.node.add_marker(pytest.mark.xfail(reason='subtract not supported'))
     if source == 'gateway-over-datafusion' and originalname == 'test_intersect':
-        request.node.add_marker(pytest.mark.xfail(reason='intersect not supported"))
+        request.node.add_marker(pytest.mark.xfail(reason='intersect not supported'))
 
             # pylint: disable=missing-function-docstring
 # ruff: noqa: E712
@@ -289,7 +289,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_union(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -305,7 +304,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_union_distinct(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -319,7 +317,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_unionall(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -335,7 +332,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_exceptall(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
@@ -367,7 +363,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_subtract(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
@@ -389,7 +384,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_intersect(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -405,7 +399,6 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_unionbyname(self, spark_session):
         expected = [
             Row(a=1, b=2, c=3),
@@ -428,13 +421,7 @@ only showing top 1 row
             outcome = df.unionByName(df2).collect()
             assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_unionbyname_with_mismatched_columns(self, spark_session):
-        expected = [
-            Row(a=1, b=2, c=3, d=None),
-            Row(a=None, b=4, c=5, d=6),
-        ]
-
         int1_array = pa.array([1], type=pa.int32())
         int2_array = pa.array([2], type=pa.int32())
         int3_array = pa.array([3], type=pa.int32())
@@ -450,7 +437,6 @@ only showing top 1 row
         with pytest.raises(pyspark.errors.exceptions.captured.AnalysisException):
             df.unionByName(df2).collect()
 
-    @pytest.mark.interesting
     def test_unionbyname_with_missing_columns(self, spark_session):
         expected = [
             Row(a=1, b=2, c=3, d=None),

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -34,8 +34,18 @@ def mark_dataframe_tests_as_xfail(request):
     elif source == 'spark' and originalname == 'test_subquery_alias':
         pytest.xfail('Spark supports subquery_alias but everyone else does not')
 
+    if source != 'spark' and originalname.startswith('test_unionbyname'):
+        request.node.add_marker(pytest.mark.xfail(reason='unionByName not supported in Substrait'))
+    if source != 'spark' and originalname.startswith('test_exceptall'):
+        request.node.add_marker(pytest.mark.xfail(reason='exceptAll not supported in Substrait'))
+    if source == 'gateway-over-duckdb' and originalname in ['test_union', 'test_unionall']:
+        request.node.add_marker(pytest.mark.xfail(reason='DuckDB treats all unions as distinct'))
+    if source == 'gateway-over-datafusion' and originalname == 'test_subtract':
+        request.node.add_marker(pytest.mark.xfail(reason='subtract not supported"))
+    if source == 'gateway-over-datafusion' and originalname == 'test_intersect':
+        request.node.add_marker(pytest.mark.xfail(reason='intersect not supported"))
 
-# pylint: disable=missing-function-docstring
+            # pylint: disable=missing-function-docstring
 # ruff: noqa: E712
 class TestDataFrameAPI:
     """Tests of the dataframe side of SparkConnect."""
@@ -279,6 +289,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_union(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -294,6 +305,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_union_distinct(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -307,6 +319,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_unionall(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -322,6 +335,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_exceptall(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
@@ -353,6 +367,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_subtract(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
@@ -374,6 +389,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_intersect(self, spark_session_with_tpch_dataset):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
@@ -389,6 +405,7 @@ only showing top 1 row
 
         assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_unionbyname(self, spark_session):
         expected = [
             Row(a=1, b=2, c=3),
@@ -411,6 +428,7 @@ only showing top 1 row
             outcome = df.unionByName(df2).collect()
             assertDataFrameEqual(outcome, expected)
 
+    @pytest.mark.interesting
     def test_unionbyname_with_mismatched_columns(self, spark_session):
         expected = [
             Row(a=1, b=2, c=3, d=None),
@@ -432,6 +450,7 @@ only showing top 1 row
         with pytest.raises(pyspark.errors.exceptions.captured.AnalysisException):
             df.unionByName(df2).collect()
 
+    @pytest.mark.interesting
     def test_unionbyname_with_missing_columns(self, spark_session):
         expected = [
             Row(a=1, b=2, c=3, d=None),


### PR DESCRIPTION
Basic union, subtract, and intersect support is added.  Substrait does not define
some forms so those will return errors.  Also backends have their own varying
support.