### PR TITLE
feat: speed up queries by reading minimal data from homogenous-schema

### DIFF
--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -102,8 +102,8 @@ class DuckDBBackend(Backend):
         if len(paths) == 1:
             files = Backend._expand_location(paths[0])
         # TODO -- Handle resolution of a combined schema.
-        df = self._connection.execute(f"SELECT * FROM read_parquet({files}) LIMIT 1")
-        schema = df.fetch_arrow_table().schema
+        df = self._connection.read_parquet(files)
+        schema = df.fetch_arrow_reader().schema
         if 'aggr' in schema.names:
             raise ValueError("Aggr column found in schema")
         return schema

--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -102,8 +102,8 @@ class DuckDBBackend(Backend):
         if len(paths) == 1:
             files = Backend._expand_location(paths[0])
         # TODO -- Handle resolution of a combined schema.
-        df = self._connection.read_parquet(files)
-        schema = df.to_arrow_table().schema
+        df = self._connection.execute(f"SELECT * FROM read_parquet({files}) LIMIT 1")
+        schema = df.fetch_arrow_table().schema
         if 'aggr' in schema.names:
             raise ValueError("Aggr column found in schema")
         return schema


### PR DESCRIPTION
Queries on our parquet-datasets (`> 1Gb`) show `< 3 seconds` added to every query-execution.

This PR speeds up the execution times.