### PR TITLE
feat: support short-type in arrow schema

### DIFF
--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -791,6 +791,8 @@ class SparkSubstraitConverter:
             match str(field.type):
                 case 'bool':
                     field_type = type_pb2.Type(bool=type_pb2.Type.Boolean(nullability=nullability))
+                case 'int8':
+                    field_type = type_pb2.Type(i8=type_pb2.Type.I8(nullability=nullability))
                 case 'int16':
                     field_type = type_pb2.Type(i16=type_pb2.Type.I16(nullability=nullability))
                 case 'int32':


### PR DESCRIPTION
 
Our queries fail on some datasets that have "ShortType" fields.
https://spark.apache.org/docs/latest/sql-ref-datatypes.html#supported-data-types

This PR adds schema-support for "ShortType" fields.