### PR TITLE
feat: support get_option for local-rel threshold

### DIFF
--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -354,6 +354,9 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
                 for key in request.operation.get_option.keys:
                     if key == 'spark.sql.session.timeZone':
                         response.pairs.add(key=key, value='UTC')
+                    elif key in ['spark.sql.session.localRelationCacheThreshold',
+                                 'spark.sql.repl.eagerEval.maxNumRows']:
+                        response.pairs.add(key=key, value='9999')
                     else:
                         _LOGGER.info(f'Unknown config item: {key}')
                         raise NotImplementedError(f'Unknown config item: {key}')


### PR DESCRIPTION
SparkConnect's Scala client currently fails for spark.createDataFrame() requests 
with a `NotImplementedError`.

The Scala client for this API submits a request to `"get_option"` with 
key `"localRelationCacheThreshold"`. 
We only support ConfigRequests for this key if `"op_type"`  is `"get"`. 

fixes #61 
