### PR TITLE
fix: replace backticks with quotes in sql

### DIFF
--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -119,6 +119,6 @@ class DuckDBBackend(Backend):
     def convert_sql(self, sql: str) -> plan_pb2.Plan:
         """Convert SQL into a Substrait plan."""
         plan = plan_pb2.Plan()
-        proto_bytes = self._connection.get_substrait(query=sql).fetchone()[0]
+        proto_bytes = self._connection.get_substrait(query=sql.replace("`", "'")).fetchone()[0]
         plan.ParseFromString(proto_bytes)
         return plan

--- a/src/gateway/tests/test_tpcds_sql.py
+++ b/src/gateway/tests/test_tpcds_sql.py
@@ -18,14 +18,14 @@ def mark_tests_as_xfail(request):
     source = request.getfixturevalue('source')
     if source == 'gateway-over-duckdb':
         path = request.getfixturevalue('path')
-        if path.stem in ['01', '06', '10', '30', '35', '69', '81', '86']:
+        if path.stem in ['01', '06', '10', '16', '30', '32', '35', '69', '81', '86', '92', '94']:
             pytest.skip(reason='DuckDB needs Delim join')
         elif path.stem in ['02', '03', '04', '05', '07', '08', '11', '13', '14', '15', '17',
                            '18', '19', '21', '22', '23', '25', '26', '27', '29', '31', '33',
-                           '34', '37', '39', '40', '42', '43', '45', '46', '48', '52', '55',
-                           '56', '60', '61', '64', '65', '66', '68', '71', '72', '73', '74',
-                           '75', '77', '78', '79', '80', '82', '85', '88', '90', '91', '96',
-                           '97']:
+                           '34', '37', '39', '40', '42', '43', '45', '46', '48', '50', '52',
+                           '55', '56', '60', '61', '62', '64', '65', '66', '68', '71', '72',
+                           '73', '74', '75', '77', '78', '79', '80', '82', '85', '88', '90',
+                           '91', '96', '97', '99']:
             pytest.skip(reason='DuckDB INTERNAL Error: COMPARE_BETWEEN')
         elif path.stem in ['09']:
             pytest.skip(reason='Binder Error: Cannot compare values of type VARCHAR and '
@@ -41,10 +41,10 @@ def mark_tests_as_xfail(request):
             pytest.skip(reason='INTERNAL Error: Unsupported join type RIGHT_SEMI')
         elif path.stem in ['84']:
             pytest.skip(reason='INTERNAL Error: COALESCE')
-        elif path.stem in ['16', '32', '50', '62', '92', '94', '95', '99']:
-            pytest.skip(reason='Backtick conversion error')
         elif path.stem in ['58']:
             pytest.skip(reason='AssertionError: assert table is not None')
+        elif path.stem in ['95']:
+            pytest.skip(reason='Unsupported join comparison: !=')
     if source == 'gateway-over-datafusion':
         pytest.skip(reason='not yet ready to run SQL tests regularly')
     if source == 'gateway-over-arrow':


### PR DESCRIPTION
spark sql uses backticks instead of quotes in alias names with spaces.

This needs to be replaced when using duckdb to convert from sql to substrait