### PR TITLE
feat: switch to using the DuckDB version of the TPC-H dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Test data
+data/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/tpch"]
-	path = third_party/tpch
-	url = git@github.com:tripl-ai/tpch.git

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pyspark
     - pandas >= 1.0.5
     - pyhamcrest
-    - substrait >= 0.21.0
+    - substrait == 0.21.0
     - substrait-validator
     - pytest-timeout
     - protobuf >= 4.25.3, < 5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name = "Substrait contributors", email = "substrait@googlegroups.com
 license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.8.1"
-dependencies = ["protobuf >= 3.20", "datafusion >= 39.0.0", "pyarrow >= 15.0.2", "substrait >= 0.21.0"]
+dependencies = ["protobuf >= 3.20", "datafusion >= 39.0.0", "pyarrow >= 15.0.2", "substrait == 0.21.0"]
 dynamic = ["version"]
 
 [tool.setuptools_scm]

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -16,6 +16,7 @@ class FunctionType(Enum):
     AGGREGATE = 3
 
 
+
 # pylint: disable=E1101
 @dataclasses.dataclass
 class ExtensionFunction:

--- a/src/gateway/converter/spark_functions.py
+++ b/src/gateway/converter/spark_functions.py
@@ -16,7 +16,6 @@ class FunctionType(Enum):
     AGGREGATE = 3
 
 
-
 # pylint: disable=E1101
 @dataclasses.dataclass
 class ExtensionFunction:

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -812,7 +812,7 @@ class SparkSubstraitConverter:
                         more_names.extend(y.name)
                         field_type.struct.types.extend(sub_type.struct.types)
                     return field_type
-                raise NotImplementedError(f'Unexpected field type: {arrow_type}')
+                raise NotImplementedError(f'Unexpected arrow datatype: {arrow_type}')
 
         return field_type, more_names
 
@@ -875,8 +875,14 @@ class SparkSubstraitConverter:
                         field_type = type_pb2.Type(
                             map=type_pb2.Type.Map(nullability=nullability, key=key_type,
                                                   value=value_type))
+                    elif str(field.type).startswith('decimal'):
+                        field_type = type_pb2.Type(
+                            decimal=type_pb2.Type.Decimal(nullability=nullability,
+                                                          precision=9,
+                                                          scale=2))
                     else:
-                        raise NotImplementedError(f'Unexpected field type: {field.type}')
+                        raise NotImplementedError(
+                            f'Unexpected arrow schema field type: {field.type}')
 
             schema.struct.types.append(field_type)
         return schema

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -67,6 +67,14 @@ class ExpressionProcessingMode(Enum):
     AGGR_UNDER_AGGREGATE = 3
 
 
+def _extract_decimal_parameters(type_name: str) -> tuple[int, int, int]:
+    """Extract the precision and scale from a decimal type name."""
+    match = re.match(r'decimal(\d*)?\((\d+), *(\d+)\)', type_name)
+    if not match:
+        raise ValueError(f'Invalid decimal type name: {type_name}')
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
 # ruff: noqa: RUF005
 class SparkSubstraitConverter:
     """Converts SparkConnect plans to Substrait plans."""
@@ -876,10 +884,11 @@ class SparkSubstraitConverter:
                             map=type_pb2.Type.Map(nullability=nullability, key=key_type,
                                                   value=value_type))
                     elif str(field.type).startswith('decimal'):
+                        _, precision, scale = _extract_decimal_parameters(str(field.type))
                         field_type = type_pb2.Type(
                             decimal=type_pb2.Type.Decimal(nullability=nullability,
-                                                          precision=9,
-                                                          scale=2))
+                                                          precision=precision,
+                                                          scale=scale))
                     else:
                         raise NotImplementedError(
                             f'Unexpected arrow schema field type: {field.type}')

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -68,7 +68,7 @@ class ExpressionProcessingMode(Enum):
 
 
 def _extract_decimal_parameters(type_name: str) -> tuple[int, int, int]:
-    """Extract the precision and scale from a decimal type name."""
+    """Extract the bytes used, precision, and scale from a decimal type name."""
     match = re.match(r'decimal(\d*)?\((\d+), *(\d+)\)', type_name)
     if not match:
         raise ValueError(f'Invalid decimal type name: {type_name}')

--- a/src/gateway/converter/tests/data/count.sql-splan
+++ b/src/gateway/converter/tests/data/count.sql-splan
@@ -43,7 +43,7 @@ relations {
                       }
                     }
                     types {
-                      i64 {
+                      i32 {
                         nullability: NULLABILITY_NULLABLE
                       }
                     }
@@ -53,7 +53,9 @@ relations {
                       }
                     }
                     types {
-                      fp64 {
+                      decimal {
+                        scale: 2
+                        precision: 15
                         nullability: NULLABILITY_NULLABLE
                       }
                     }

--- a/src/gateway/converter/tests/data/select.sql-splan
+++ b/src/gateway/converter/tests/data/select.sql-splan
@@ -30,7 +30,7 @@ relations {
                   }
                 }
                 types {
-                  i64 {
+                  i32 {
                     nullability: NULLABILITY_NULLABLE
                   }
                 }
@@ -40,7 +40,9 @@ relations {
                   }
                 }
                 types {
-                  fp64 {
+                  decimal {
+                    scale: 2
+                    precision: 15
                     nullability: NULLABILITY_NULLABLE
                   }
                 }

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -11,7 +11,7 @@ from backends.backend_selector import find_backend
 from gateway.converter.conversion_options import duck_db
 from gateway.converter.spark_to_substrait import SparkSubstraitConverter
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
-from gateway.tests.conftest import find_tpch
+from gateway.tests.conftest import find_tpch, prepare_tpch_parquet_data
 
 test_case_directory = Path(__file__).resolve().parent / 'data'
 
@@ -59,7 +59,7 @@ def test_plan_conversion(request, path):
 
 
 @pytest.fixture(autouse=True)
-def manage_database() -> None:
+def manage_database(prepare_tpch_parquet_data) -> None:
     """Creates the mystream database for use throughout all the tests."""
     create_mystream_database()
     yield

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait plan conversion routines."""
+# ruff: noqa: F401
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,7 @@ from backends.backend_selector import find_backend
 from gateway.converter.conversion_options import duck_db
 from gateway.converter.spark_to_substrait import SparkSubstraitConverter
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
-from gateway.tests.conftest import find_tpch
+from gateway.tests.conftest import find_tpch, prepare_tpch_parquet_data
 
 test_case_directory = Path(__file__).resolve().parent / 'data'
 
@@ -67,7 +68,7 @@ def manage_database() -> None:
 
 
 @pytest.fixture(autouse=True)
-@pytest.mark.usefixtures('gateway.tests.conftest.prepare_tpch_parquet_data')
+@pytest.mark.usefixtures('prepare_tpch_parquet_data')
 def prepare_tpch_data() -> None:
     """Prepare the TPCH data for the tests."""
     pass

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -59,19 +59,13 @@ def test_plan_conversion(request, path):
     assert substrait == substrait_plan
 
 
+# ruff: noqa: F811
 @pytest.fixture(autouse=True)
-def manage_database() -> None:
+def manage_database(prepare_tpch_parquet_data) -> None:
     """Creates the mystream database for use throughout all the tests."""
     create_mystream_database()
     yield
     delete_mystream_database()
-
-
-@pytest.fixture(autouse=True)
-@pytest.mark.usefixtures('prepare_tpch_parquet_data')
-def prepare_tpch_data() -> None:
-    """Prepare the TPCH data for the tests."""
-    pass
 
 
 # pylint: disable=E1101

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -11,7 +11,7 @@ from backends.backend_selector import find_backend
 from gateway.converter.conversion_options import duck_db
 from gateway.converter.spark_to_substrait import SparkSubstraitConverter
 from gateway.demo.mystream_database import create_mystream_database, delete_mystream_database
-from gateway.tests.conftest import find_tpch, prepare_tpch_parquet_data
+from gateway.tests.conftest import find_tpch
 
 test_case_directory = Path(__file__).resolve().parent / 'data'
 
@@ -67,7 +67,8 @@ def manage_database() -> None:
 
 
 @pytest.fixture(autouse=True)
-def prepare_tpch_data(prepare_tpch_parquet_data) -> None:
+@pytest.mark.usefixtures('gateway.tests.conftest.prepare_tpch_parquet_data')
+def prepare_tpch_data() -> None:
     """Prepare the TPCH data for the tests."""
     pass
 

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -59,11 +59,17 @@ def test_plan_conversion(request, path):
 
 
 @pytest.fixture(autouse=True)
-def manage_database(prepare_tpch_parquet_data) -> None:
+def manage_database() -> None:
     """Creates the mystream database for use throughout all the tests."""
     create_mystream_database()
     yield
     delete_mystream_database()
+
+
+@pytest.fixture(autouse=True)
+def prepare_tpch_data(prepare_tpch_parquet_data) -> None:
+    """Prepare the TPCH data for the tests."""
+    pass
 
 
 # pylint: disable=E1101

--- a/src/gateway/converter/tests/spark_to_substrait_test.py
+++ b/src/gateway/converter/tests/spark_to_substrait_test.py
@@ -86,7 +86,7 @@ def test_sql_conversion(request, path):
 
     options = duck_db()
     backend = find_backend(options.backend)
-    backend.register_table('customer', find_tpch() / 'customer')
+    backend.register_table('customer', find_tpch() / 'customer.parquet')
     substrait = backend.convert_sql(str(sql))
 
     if request.config.getoption('rebuild_goldens'):

--- a/src/gateway/tests/compare_dataframes.py
+++ b/src/gateway/tests/compare_dataframes.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Routines for comparing dataframes."""
 import datetime
-from decimal import Decimal
 
 from pyspark import Row
 from pyspark.testing import assertDataFrameEqual

--- a/src/gateway/tests/compare_dataframes.py
+++ b/src/gateway/tests/compare_dataframes.py
@@ -41,4 +41,4 @@ def assert_dataframes_equal(outcome: list[Row], expected: list[Row]):
     # Create a copy of the dataframes to avoid modifying the original ones
     modified_outcome = align_schema(outcome, expected)
 
-    assertDataFrameEqual(modified_outcome, expected, atol=1e-2)
+    assertDataFrameEqual(modified_outcome, expected, checkRowOrder=True, atol=1e-2)

--- a/src/gateway/tests/compare_dataframes.py
+++ b/src/gateway/tests/compare_dataframes.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Routines for comparing dataframes."""
 import datetime
+from decimal import Decimal
 
 from pyspark import Row
 from pyspark.testing import assertDataFrameEqual
@@ -22,12 +23,19 @@ def align_schema(source_df: list[Row], schema_df: list[Row]):
     for row in source_df:
         new_row = {}
         for field_name, field_value in schema.asDict().items():
-            if (type(row[field_name] is not type(field_value)) and
-                    isinstance(field_value, datetime.date)):
-                if row[field_name] is None:
-                    new_row[field_name] = row[field_name]
+            if type(row[field_name]) is not type(field_value):
+                if isinstance(field_value, datetime.date):
+                    if row[field_name] is None:
+                        new_row[field_name] = None
+                    else:
+                        new_row[field_name] = row[field_name].date()
+                elif isinstance(field_value, float):
+                    if row[field_name] is None:
+                        new_row[field_name] = None
+                    else:
+                        new_row[field_name] = float(row[field_name])
                 else:
-                    new_row[field_name] = row[field_name].date()
+                    new_row[field_name] = row[field_name]
             else:
                 new_row[field_name] = row[field_name]
 

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -234,7 +234,8 @@ def _prepare_data(benchmark, scale_factor):
 
 
 @pytest.fixture(scope='class')
-def register_tpcds_dataset(spark_session_for_setup: SparkSession, prepare_tpcds_parquet_data) -> None:
+def register_tpcds_dataset(spark_session_for_setup: SparkSession,
+                           prepare_tpcds_parquet_data) -> None:
     """Add the TPC-DS dataset to the current spark session."""
     benchmark = 'tpcds'
     _register_table(spark_session_for_setup, benchmark, 'call_center')

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -139,7 +139,7 @@ def find_tpch() -> Path:
     """Find the location of the TPC-H dataset."""
     current_location = Path('.').resolve()
     while current_location != Path('/'):
-        location = current_location / 'third_party' / 'tpch' / 'parquet'
+        location = current_location / 'data' / 'tpch' / 'parquet'
         if location.exists():
             return location.resolve()
         current_location = current_location.parent
@@ -165,12 +165,12 @@ def _register_table(spark_session: SparkSession, benchmark: str, name: str) -> N
         location = find_tpcds() / name
     else:
         raise ValueError(f'Unknown benchmark: {benchmark}')
-    df = spark_session.read.parquet(str(location))
-    df.createOrReplaceTempView(Path(location).stem)
+    df = spark_session.read.parquet(str(location.with_suffix('.parquet')))
+    df.createOrReplaceTempView(name)
 
 
 @pytest.fixture(scope='class')
-def register_tpch_dataset(spark_session_for_setup: SparkSession) -> None:
+def register_tpch_dataset(spark_session_for_setup: SparkSession, prepare_tpch_parquet_data) -> None:
     """Add the TPC-H dataset to the current spark session."""
     benchmark = 'tpch'
     _register_table(spark_session_for_setup, benchmark, 'customer')
@@ -183,13 +183,13 @@ def register_tpch_dataset(spark_session_for_setup: SparkSession) -> None:
     _register_table(spark_session_for_setup, benchmark, 'supplier')
 
 
-def get_project_root() -> Path:
+def _get_project_root() -> Path:
     """Finds the root of the project."""
     return Path(__file__).parent.parent.parent.parent
 
 
 @pytest.fixture(scope="session")
-def prepare_tpch_parquet_data(scale_factor=0.1):
+def prepare_tpch_parquet_data(scale_factor=1):
     """
     Generate TPC-H data to be used for testing.
 
@@ -197,7 +197,7 @@ def prepare_tpch_parquet_data(scale_factor=0.1):
         scale_factor:
             Scale factor for TPC-H data generation.
     """
-    prepare_data("tpch", scale_factor)
+    _prepare_data("tpch", scale_factor)
 
 
 @pytest.fixture(scope="session")
@@ -209,10 +209,10 @@ def prepare_tpcds_parquet_data(scale_factor=0.1):
         scale_factor:
             Scale factor for TPC-DS data generation.
     """
-    prepare_data("tpcds", scale_factor)
+    _prepare_data("tpcds", scale_factor)
 
 
-def prepare_data(benchmark, scale_factor):
+def _prepare_data(benchmark, scale_factor):
     """
     Generate the benchmark data to be used for testing.
 
@@ -220,7 +220,7 @@ def prepare_data(benchmark, scale_factor):
         benchmark:
             TPCH or TPCDS.
     """
-    data_path = get_project_root() / "data" / benchmark / "parquet"
+    data_path = _get_project_root() / "data" / benchmark / "parquet"
     if benchmark == 'tpch':
         generator = 'dbgen'
     elif benchmark == 'tpcds':
@@ -234,30 +234,30 @@ def prepare_data(benchmark, scale_factor):
 
 
 @pytest.fixture(scope='class')
-def register_tpcds_dataset(spark_session_for_setup: SparkSession) -> None:
+def register_tpcds_dataset(spark_session_for_setup: SparkSession, prepare_tpcds_parquet_data) -> None:
     """Add the TPC-DS dataset to the current spark session."""
     benchmark = 'tpcds'
-    _register_table(spark_session_for_setup, benchmark, 'call_center.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'catalog_page.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'catalog_returns.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'catalog_sales.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'customer.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'customer_address.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'customer_demographics.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'date_dim.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'household_demographics.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'income_band.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'inventory.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'item.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'promotion.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'reason.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'ship_mode.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'store.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'store_returns.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'store_sales.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'time_dim.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'warehouse.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'web_page.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'web_returns.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'web_sales.parquet')
-    _register_table(spark_session_for_setup, benchmark, 'web_site.parquet')
+    _register_table(spark_session_for_setup, benchmark, 'call_center')
+    _register_table(spark_session_for_setup, benchmark, 'catalog_page')
+    _register_table(spark_session_for_setup, benchmark, 'catalog_returns')
+    _register_table(spark_session_for_setup, benchmark, 'catalog_sales')
+    _register_table(spark_session_for_setup, benchmark, 'customer')
+    _register_table(spark_session_for_setup, benchmark, 'customer_address')
+    _register_table(spark_session_for_setup, benchmark, 'customer_demographics')
+    _register_table(spark_session_for_setup, benchmark, 'date_dim')
+    _register_table(spark_session_for_setup, benchmark, 'household_demographics')
+    _register_table(spark_session_for_setup, benchmark, 'income_band')
+    _register_table(spark_session_for_setup, benchmark, 'inventory')
+    _register_table(spark_session_for_setup, benchmark, 'item')
+    _register_table(spark_session_for_setup, benchmark, 'promotion')
+    _register_table(spark_session_for_setup, benchmark, 'reason')
+    _register_table(spark_session_for_setup, benchmark, 'ship_mode')
+    _register_table(spark_session_for_setup, benchmark, 'store')
+    _register_table(spark_session_for_setup, benchmark, 'store_returns')
+    _register_table(spark_session_for_setup, benchmark, 'store_sales')
+    _register_table(spark_session_for_setup, benchmark, 'time_dim')
+    _register_table(spark_session_for_setup, benchmark, 'warehouse')
+    _register_table(spark_session_for_setup, benchmark, 'web_page')
+    _register_table(spark_session_for_setup, benchmark, 'web_returns')
+    _register_table(spark_session_for_setup, benchmark, 'web_sales')
+    _register_table(spark_session_for_setup, benchmark, 'web_site')

--- a/src/gateway/tests/conftest.py
+++ b/src/gateway/tests/conftest.py
@@ -137,23 +137,17 @@ def users_dataframe(spark_session, register_users_dataset):
 
 def find_tpch() -> Path:
     """Find the location of the TPC-H dataset."""
-    current_location = Path('.').resolve()
-    while current_location != Path('/'):
-        location = current_location / 'data' / 'tpch' / 'parquet'
-        if location.exists():
-            return location.resolve()
-        current_location = current_location.parent
+    location = _get_project_root() / 'data' / 'tpch' / 'parquet'
+    if location.exists():
+        return location.resolve()
     raise ValueError('TPC-H dataset not found')
 
 
 def find_tpcds() -> Path:
     """Find the location of the TPC-DS dataset."""
-    current_location = Path('.').resolve()
-    while current_location != Path('/'):
-        location = current_location / 'data' / 'tpcds' / 'parquet'
-        if location.exists():
-            return location.resolve()
-        current_location = current_location.parent
+    location = _get_project_root() / 'data' / 'tpcds' / 'parquet'
+    if location.exists():
+        return location.resolve()
     raise ValueError('TPC-DS dataset not found')
 
 

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -775,11 +775,11 @@ only showing top 1 row
 
     def test_between(self, register_tpch_dataset, spark_session):
         expected = [
+            Row(n_name='ALGERIA', is_between=False),
             Row(n_name='ARGENTINA', is_between=False),
             Row(n_name='BRAZIL', is_between=False),
             Row(n_name='CANADA', is_between=False),
             Row(n_name='EGYPT', is_between=True),
-            Row(n_name='ETHIOPIA', is_between=False),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -959,7 +959,7 @@ only showing top 1 row
         with utilizes_valid_plans(spark_session):
             outcome = spark_session.table('customer').collect()
 
-        assert len(outcome) == 149999
+        assert len(outcome) == 150000
 
     def test_table_schema(self, register_tpch_dataset, spark_session):
         schema = spark_session.table('customer').schema
@@ -981,7 +981,7 @@ only showing top 1 row
         with utilizes_valid_plans(spark_session):
             outcome = spark_session.table('mytempview').collect()
 
-        assert len(outcome) == 149999
+        assert len(outcome) == 150000
 
     def test_create_or_replace_multiple_temp_views(self, spark_session):
         location_customer = str(find_tpch() / 'customer.parquet')
@@ -993,7 +993,7 @@ only showing top 1 row
             outcome1 = spark_session.table('mytempview1').collect()
             outcome2 = spark_session.table('mytempview2').collect()
 
-        assert len(outcome1) == len(outcome2) == 149999
+        assert len(outcome1) == len(outcome2) == 150000
 
 
 class TestDataFrameAPIFunctions:

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Spark to Substrait Gateway server."""
+from decimal import Decimal
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyspark
@@ -509,10 +511,10 @@ only showing top 1 row
     def test_join(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=5, n_name='ETHIOPIA', n_regionkey=0,
-                n_comment='ven packages wake quickly. regu', s_suppkey=2,
-                s_name='Supplier#000000002', s_address='89eJ5ksX3ImxJQBvxObC,', s_nationkey=5,
-                s_phone='15-679-861-2259', s_acctbal=4032.68,
-                s_comment=' slyly bold instructions. idle dependen'),
+                n_comment='regular requests sleep carefull', s_suppkey=2,
+                s_name='Supplier#000000002', s_address='TRMhVHz3XiFuhapxucPo1', s_nationkey=5,
+                s_phone='15-679-861-2259', s_acctbal=Decimal('4032.68'),
+                s_comment=' the pending packages. furiously expres'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -545,9 +547,9 @@ only showing top 1 row
     def test_union(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -560,7 +562,7 @@ only showing top 1 row
     def test_union_distinct(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -573,9 +575,9 @@ only showing top 1 row
     def test_unionall(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -588,23 +590,23 @@ only showing top 1 row
     def test_exceptall(self, register_tpch_dataset, spark_session, caplog):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
-                n_comment='hely enticingly express accounts. even, final '),
+                n_comment='lly across the quickly even pinto beans. caref'),
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
-                n_comment='hely enticingly express accounts. even, final '),
+                n_comment='lly across the quickly even pinto beans. caref'),
             Row(n_nationkey=22, n_name='RUSSIA', n_regionkey=3,
-                n_comment=' requests against the platelets use never according to the '
-                          'quickly regular pint'),
+                n_comment='uctions. furiously unusual instructions sleep furiously ironic '
+                          'packages. slyly '),
             Row(n_nationkey=22, n_name='RUSSIA', n_regionkey=3,
-                n_comment=' requests against the platelets use never according to the '
-                          'quickly regular pint'),
+                n_comment='uctions. furiously unusual instructions sleep furiously ironic '
+                          'packages. slyly '),
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
             Row(n_nationkey=24, n_name='UNITED STATES', n_regionkey=1,
-                n_comment='y final packages. slow foxes cajole quickly. quickly silent platelets '
-                          'breach ironic accounts. unusual pinto be'),
+                n_comment='ly ironic requests along the slyly bold ideas hang after the '
+                          'blithely special notornis; blithely even accounts'),
             Row(n_nationkey=24, n_name='UNITED STATES', n_regionkey=1,
-                n_comment='y final packages. slow foxes cajole quickly. quickly silent platelets '
-                          'breach ironic accounts. unusual pinto be'),
+                n_comment='ly ironic requests along the slyly bold ideas hang after the '
+                          'blithely special notornis; blithely even accounts'),
         ]
 
         with utilizes_valid_plans(spark_session, caplog):
@@ -680,13 +682,13 @@ only showing top 1 row
     def test_subtract(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=21, n_name='VIETNAM', n_regionkey=2,
-                n_comment='hely enticingly express accounts. even, final '),
+                n_comment='lly across the quickly even pinto beans. caref'),
             Row(n_nationkey=22, n_name='RUSSIA', n_regionkey=3,
-                n_comment=' requests against the platelets use never according to the '
-                          'quickly regular pint'),
+                n_comment='uctions. furiously unusual instructions sleep furiously '
+                          'ironic packages. slyly '),
             Row(n_nationkey=24, n_name='UNITED STATES', n_regionkey=1,
-                n_comment='y final packages. slow foxes cajole quickly. quickly silent platelets '
-                          'breach ironic accounts. unusual pinto be'),
+                n_comment='ly ironic requests along the slyly bold ideas hang after '
+                          'the blithely special notornis; blithely even accounts'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -701,7 +703,7 @@ only showing top 1 row
     def test_intersect(self, register_tpch_dataset, spark_session):
         expected = [
             Row(n_nationkey=23, n_name='UNITED KINGDOM', n_regionkey=3,
-                n_comment='eans boost carefully special requests. accounts are. carefull'),
+                n_comment='carefully pending courts sleep above the ironic, regular theo'),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -526,11 +526,11 @@ only showing top 1 row
 
     def test_crossjoin(self, register_tpch_dataset, spark_session):
         expected = [
+            Row(n_nationkey=0, n_name='ALGERIA', s_name='Supplier#000000002'),
             Row(n_nationkey=1, n_name='ARGENTINA', s_name='Supplier#000000002'),
             Row(n_nationkey=2, n_name='BRAZIL', s_name='Supplier#000000002'),
             Row(n_nationkey=3, n_name='CANADA', s_name='Supplier#000000002'),
             Row(n_nationkey=4, n_name='EGYPT', s_name='Supplier#000000002'),
-            Row(n_nationkey=5, n_name='ETHIOPIA', s_name='Supplier#000000002'),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -144,6 +144,10 @@ def mark_dataframe_tests_as_xfail(request):
         pytest.skip(reason='missing in Substrait')
     if source == 'gateway-over-datafusion' and originalname == 'test_try_divide':
         pytest.skip(reason='returns infinity instead of null')
+    if source == 'gateway-over-datafusion' and originalname in ['test_data_source_schema',
+                                                                'test_data_source_filter',
+                                                                'test_data_source_options']:
+        pytest.skip(reason='list index out of range')
 
 
 # ruff: noqa: E712

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -932,12 +932,12 @@ only showing top 1 row
                     'substr(user_id, 5, 9)', 'not paid_for_service').limit(1).collect()
 
     def test_data_source_schema(self, spark_session):
-        location_customer = str(find_tpch() / 'customer')
+        location_customer = str(find_tpch() / 'customer.parquet')
         schema = spark_session.read.parquet(location_customer).schema
         assert len(schema) == 8
 
     def test_data_source_filter(self, spark_session):
-        location_customer = str(find_tpch() / 'customer')
+        location_customer = str(find_tpch() / 'customer.parquet')
         customer_dataframe = spark_session.read.parquet(location_customer)
 
         with utilizes_valid_plans(spark_session):
@@ -946,7 +946,7 @@ only showing top 1 row
         assert len(outcome) == 29968
 
     def test_data_source_options(self, spark_session):
-        location_customer = str(find_tpch() / 'customer')
+        location_customer = str(find_tpch() / 'customer.parquet')
         spark_options = {"path": location_customer}
         customer_dataframe = spark_session.read.format('parquet').options(**spark_options).load()
 
@@ -974,7 +974,7 @@ only showing top 1 row
         assert len(outcome) == 29968
 
     def test_create_or_replace_temp_view(self, spark_session):
-        location_customer = str(find_tpch() / 'customer')
+        location_customer = str(find_tpch() / 'customer.parquet')
         df_customer = spark_session.read.parquet(location_customer)
         df_customer.createOrReplaceTempView("mytempview")
 
@@ -984,7 +984,7 @@ only showing top 1 row
         assert len(outcome) == 149999
 
     def test_create_or_replace_multiple_temp_views(self, spark_session):
-        location_customer = str(find_tpch() / 'customer')
+        location_customer = str(find_tpch() / 'customer.parquet')
         df_customer = spark_session.read.parquet(location_customer)
         df_customer.createOrReplaceTempView("mytempview1")
         df_customer.createOrReplaceTempView("mytempview2")

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -70,15 +70,15 @@ class TestSqlAPI:
             outcome = spark_session.sql(
                 'SELECT COUNT(*) FROM customer').collect()
 
-        assert_that(outcome[0][0], equal_to(149999))
+        assert_that(outcome[0][0], equal_to(150000))
 
     def test_limit(self, register_tpch_dataset, spark_session):
         expected = [
+            Row(c_custkey=1, c_phone='25-989-741-2988', c_mktsegment='BUILDING'),
             Row(c_custkey=2, c_phone='23-768-687-3665', c_mktsegment='AUTOMOBILE'),
             Row(c_custkey=3, c_phone='11-719-748-3364', c_mktsegment='AUTOMOBILE'),
             Row(c_custkey=4, c_phone='14-128-190-5944', c_mktsegment='MACHINERY'),
             Row(c_custkey=5, c_phone='13-750-942-6364', c_mktsegment='HOUSEHOLD'),
-            Row(c_custkey=6, c_phone='30-114-968-4951', c_mktsegment='AUTOMOBILE'),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_sql_api.py
+++ b/src/gateway/tests/test_sql_api.py
@@ -25,8 +25,6 @@ def mark_tests_as_xfail(request):
             path = request.getfixturevalue('path')
             if path.stem in ['02', '04', '16', '17', '20', '21', '22']:
                 pytest.skip(reason='DuckDB needs Delim join')
-            elif path.stem in ['15']:
-                pytest.skip(reason='Rounding inconsistency')
             elif path.stem in ['01', '06', '13', '14']:
                 pytest.skip(reason='Too few names returned')
             elif path.stem in ['19']:
@@ -50,8 +48,6 @@ def mark_tests_as_xfail(request):
                 request.node.add_marker(pytest.mark.xfail(reason='first not implemented'))
             elif path.stem in ['13']:
                 request.node.add_marker(pytest.mark.xfail(reason='not rlike not implemented'))
-            elif path.stem in ['15']:
-                request.node.add_marker(pytest.mark.xfail(reason='empty table error'))
             elif path.stem in ['16']:
                 request.node.add_marker(pytest.mark.xfail(reason='mark join not implemented'))
             elif path.stem in ['18']:

--- a/src/gateway/tests/test_tpcds_sql.py
+++ b/src/gateway/tests/test_tpcds_sql.py
@@ -52,7 +52,6 @@ def mark_tests_as_xfail(request):
         pytest.skip(reason='not yet ready to run SQL tests regularly')
 
 
-@pytest.mark.usefixtures("prepare_tpcds_parquet_data")
 class TestTpcds:
 
     @pytest.mark.timeout(60)

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -46,9 +46,9 @@ class TestTpchWithDataFrameAPI:
                 sum_base_price=Decimal('56586554400.73'),
                 sum_disc_price=Decimal('53758257134.8700'),
                 sum_charge=Decimal('55909065222.827692'),
-                avg_qty=Decimal('25.522006'),
-                avg_price=Decimal('38273.129735'),
-                avg_disc=Decimal('0.049985'),
+                avg_qty=25.522006,
+                avg_price=38273.129735,
+                avg_disc=0.049985,
                 count_order=1478493),
         ]
 
@@ -274,8 +274,8 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_08(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(o_year='1995', mkt_share=Decimal('0.034436')),
-            Row(o_year='1996', mkt_share=Decimal('0.041486')),
+            Row(o_year='1995', mkt_share=0.034436),
+            Row(o_year='1996', mkt_share=0.041486),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -484,8 +484,8 @@ class TestTpchWithDataFrameAPI:
                                 (col('l_shipdate') >= '1995-09-01') &
                                 (col('l_shipdate') < '1995-10-01')).select(
                 'p_type', (col('l_extendedprice') * (1 - col('l_discount'))).alias('value')).agg(
-                try_sum(when(col('p_type').contains('PROMO'), col('value'))) * 100 / try_sum(
-                    col('value')).alias('promo_revenue')).collect()
+                (try_sum(when(col('p_type').contains('PROMO'), col('value'))) * 100 / try_sum(
+                    col('value'))).alias('promo_revenue')).collect()
 
         assert_dataframes_equal(outcome, expected)
 
@@ -545,7 +545,7 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_17(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(avg_yearly=Decimal('348406.054286')),
+            Row(avg_yearly=348406.054286),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -738,7 +738,7 @@ class TestTpchWithDataFrameAPI:
                 fcustomer, col('o_custkey') == fcustomer.c_custkey, 'right_outer').filter(
                 col('o_custkey').isNull()).join(avg_customer).filter(
                 col('c_acctbal') > col('avg_acctbal')).groupBy('cntrycode').agg(
-                count('c_custkey').alias('numcust'), try_sum('c_acctbal'))
+                count('c_custkey').alias('numcust'), try_sum('c_acctbal').alias('totacctbal'))
 
             sorted_outcome = outcome.sort('cntrycode').collect()
 

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -40,10 +40,16 @@ class TestTpchWithDataFrameAPI:
     # pylint: disable=singleton-comparison
     def test_query_01(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(l_returnflag='A', l_linestatus='F', sum_qty=Decimal(37734107.00),
-                sum_base_price=Decimal(56586554400.73), sum_disc_price=Decimal(53758257134.87),
-                sum_charge=Decimal(55909065222.83), avg_qty=Decimal(25.52),
-                avg_price=Decimal(38273.13), avg_disc=0.05, count_order=1478493),
+            Row(l_returnflag='A',
+                l_linestatus='F',
+                sum_qty=Decimal('37734107.00'),
+                sum_base_price=Decimal('56586554400.73'),
+                sum_disc_price=Decimal('53758257134.8700'),
+                sum_charge=Decimal('55909065222.827692'),
+                avg_qty=Decimal('25.522006'),
+                avg_price=Decimal('38273.129735'),
+                avg_disc=Decimal('0.049985'),
+                count_order=1478493),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -67,14 +73,14 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_02(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(s_acctbal=9938.53, s_name='Supplier#000005359', n_name='UNITED KINGDOM',
-                p_partkey=185358, p_mfgr='Manufacturer#4', s_address='QKuHYh,vZGiwu2FWEJoLDx04',
+            Row(s_acctbal=Decimal('9938.53'), s_name='Supplier#000005359', n_name='UNITED KINGDOM',
+                p_partkey=185358, p_mfgr='Manufacturer#4', s_address='bgxj2K0w1kJvxYl5mhCfou,W',
                 s_phone='33-429-790-6131',
-                s_comment='uriously regular requests hag'),
-            Row(s_acctbal=9937.84, s_name='Supplier#000005969', n_name='ROMANIA',
+                s_comment='l, ironic instructions cajole'),
+            Row(s_acctbal=Decimal('9937.84'), s_name='Supplier#000005969', n_name='ROMANIA',
                 p_partkey=108438, p_mfgr='Manufacturer#1',
-                s_address='ANDENSOSmk,miq23Xfb5RWt6dvUcvt6Qa', s_phone='29-520-692-3537',
-                s_comment='efully express instructions. regular requests against the slyly fin'),
+                s_address='rdnmd9c8EG1EIAYY3LPVa4yUNx6OwyVaQ', s_phone='29-520-692-3537',
+                s_comment='es. furiously silent deposits among the deposits haggle furiously a'),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -172,11 +178,11 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_05(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(n_name='INDONESIA', revenue=55502041.17),
-            Row(n_name='VIETNAM', revenue=55295087.00),
-            Row(n_name='CHINA', revenue=53724494.26),
-            Row(n_name='INDIA', revenue=52035512.00),
-            Row(n_name='JAPAN', revenue=45410175.70),
+            Row(n_name='JAPAN', revenue=Decimal('45410175.6954')),
+            Row(n_name='INDIA', revenue=Decimal('52035512.0002')),
+            Row(n_name='CHINA', revenue=Decimal('53724494.2566')),
+            Row(n_name='VIETNAM', revenue=Decimal('55295086.9967')),
+            Row(n_name='INDONESIA', revenue=Decimal('55502041.1697')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -208,7 +214,7 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_06(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(revenue=123141078.23),
+            Row(revenue=Decimal('123141078.2283')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -225,10 +231,14 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_07(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(supp_nation='FRANCE', cust_nation='GERMANY', l_year='1995', revenue=54639732.73),
-            Row(supp_nation='FRANCE', cust_nation='GERMANY', l_year='1996', revenue=54633083.31),
-            Row(supp_nation='GERMANY', cust_nation='FRANCE', l_year='1995', revenue=52531746.67),
-            Row(supp_nation='GERMANY', cust_nation='FRANCE', l_year='1996', revenue=52520549.02),
+            Row(supp_nation='FRANCE', cust_nation='GERMANY', l_year='1995',
+                revenue=Decimal('54639732.7336')),
+            Row(supp_nation='FRANCE', cust_nation='GERMANY', l_year='1996',
+                revenue=Decimal('54633083.3076')),
+            Row(supp_nation='GERMANY', cust_nation='FRANCE', l_year='1995',
+                revenue=Decimal('52531746.6697')),
+            Row(supp_nation='GERMANY', cust_nation='FRANCE', l_year='1996',
+                revenue=Decimal('52520549.0224')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -264,8 +274,8 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_08(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(o_year='1995', mkt_share=0.03),
-            Row(o_year='1996', mkt_share=0.04),
+            Row(o_year='1995', mkt_share=Decimal('0.034436')),
+            Row(o_year='1996', mkt_share=Decimal('0.041486')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -308,13 +318,12 @@ class TestTpchWithDataFrameAPI:
         assert_dataframes_equal(sorted_outcome, expected)
 
     def test_query_09(self, register_tpch_dataset, spark_session):
-        # TODO -- Verify the correctness of these results against another version of the dataset.
         expected = [
-            Row(n_name='ARGENTINA', o_year='1998', sum_profit=28341663.78),
-            Row(n_name='ARGENTINA', o_year='1997', sum_profit=47143964.12),
-            Row(n_name='ARGENTINA', o_year='1996', sum_profit=45255278.60),
-            Row(n_name='ARGENTINA', o_year='1995', sum_profit=45631769.21),
-            Row(n_name='ARGENTINA', o_year='1994', sum_profit=48268856.35),
+            Row(n_name='ALGERIA', o_year='1998', sum_profit=Decimal('27136900.1803')),
+            Row(n_name='ALGERIA', o_year='1997', sum_profit=Decimal('48611833.4962')),
+            Row(n_name='ALGERIA', o_year='1996', sum_profit=Decimal('48285482.6782')),
+            Row(n_name='ALGERIA', o_year='1995', sum_profit=Decimal('44402273.5999')),
+            Row(n_name='ALGERIA', o_year='1994', sum_profit=Decimal('48694008.0668')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -443,11 +452,10 @@ class TestTpchWithDataFrameAPI:
         assert_dataframes_equal(sorted_outcome, expected)
 
     def test_query_13(self, register_tpch_dataset, spark_session):
-        # TODO -- Verify the corretness of these results against another version of the dataset.
         expected = [
-            Row(c_count=9, custdist=6641),
-            Row(c_count=10, custdist=6532),
-            Row(c_count=11, custdist=6014),
+            Row(c_count=10, custdist=6668),
+            Row(c_count=9, custdist=6563),
+            Row(c_count=11, custdist=6004),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """TPC-H Dataframe tests for the Spark to Substrait Gateway server."""
 import datetime
+from decimal import Decimal
 
 import pyspark
 import pytest
@@ -39,10 +40,10 @@ class TestTpchWithDataFrameAPI:
     # pylint: disable=singleton-comparison
     def test_query_01(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(l_returnflag='A', l_linestatus='F', sum_qty=37734107.00,
-                sum_base_price=56586554400.73, sum_disc_price=53758257134.87,
-                sum_charge=55909065222.83, avg_qty=25.52,
-                avg_price=38273.13, avg_disc=0.05, count_order=1478493),
+            Row(l_returnflag='A', l_linestatus='F', sum_qty=Decimal(37734107.00),
+                sum_base_price=Decimal(56586554400.73), sum_disc_price=Decimal(53758257134.87),
+                sum_charge=Decimal(55909065222.83), avg_qty=Decimal(25.52),
+                avg_price=Decimal(38273.13), avg_disc=0.05, count_order=1478493),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -353,15 +353,14 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_10(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(c_custkey=57040, c_name='Customer#000057040', revenue=734235.25,
-                c_acctbal=632.87, n_name='JAPAN', c_address='Eioyzjf4pp',
+            Row(c_custkey=57040, c_name='Customer#000057040', revenue=Decimal('734235.2455'),
+                c_acctbal=Decimal('632.87'), n_name='JAPAN', c_address='nICtsILWBB',
                 c_phone='22-895-641-3466',
-                c_comment='sits. slyly regular requests sleep alongside of the regular inst'),
-            Row(c_custkey=143347, c_name='Customer#000143347', revenue=721002.69,
-                c_acctbal=2557.47, n_name='EGYPT', c_address='1aReFYv,Kw4',
+                c_comment='ep. blithely regular foxes promise slyly furiously ironic depend'),
+            Row(c_custkey=143347, c_name='Customer#000143347', revenue=Decimal('721002.6948'),
+                c_acctbal=Decimal('2557.47'), n_name='EGYPT', c_address=',Q9Ml3w0gvX',
                 c_phone='14-742-935-3718',
-                c_comment='ggle carefully enticing requests. final deposits use bold, bold '
-                          'pinto beans. ironic, idle re'),
+                c_comment='endencies sleep. slyly express deposits nag carefully around the even tithes. slyly regular '),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -392,11 +391,11 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_11(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(ps_partkey=129760, part_value=17538456.86),
-            Row(ps_partkey=166726, part_value=16503353.92),
-            Row(ps_partkey=191287, part_value=16474801.97),
-            Row(ps_partkey=161758, part_value=16101755.54),
-            Row(ps_partkey=34452, part_value=15983844.72),
+            Row(ps_partkey=129760, part_value=Decimal('17538456.86')),
+            Row(ps_partkey=166726, part_value=Decimal('16503353.92')),
+            Row(ps_partkey=191287, part_value=Decimal('16474801.97')),
+            Row(ps_partkey=161758, part_value=Decimal('16101755.54')),
+            Row(ps_partkey=34452, part_value=Decimal('15983844.72')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -492,8 +491,8 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_15(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(s_suppkey=8449, s_name='Supplier#000008449', s_address='Wp34zim9qYFbVctdW',
-                s_phone='20-469-856-8873', total=1772627.21),
+            Row(s_suppkey=8449, s_name='Supplier#000008449', s_address='5BXWsJERA2mP5OyO4',
+                s_phone='20-469-856-8873', total=Decimal('1772627.2087')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -546,7 +545,7 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_17(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(avg_yearly=348406.02),
+            Row(avg_yearly=Decimal('348406.054286')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -599,7 +598,7 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_19(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(revenue=3083843.06),
+            Row(revenue=Decimal('3083843.0578')),
         ]
 
         with utilizes_valid_plans(spark_session):
@@ -628,9 +627,9 @@ class TestTpchWithDataFrameAPI:
 
     def test_query_20(self, register_tpch_dataset, spark_session):
         expected = [
-            Row(s_name='Supplier#000000020', s_address='iybAE,RmTymrZVYaFZva2SH,j'),
-            Row(s_name='Supplier#000000091', s_address='YV45D7TkfdQanOOZ7q9QxkyGUapU1oOWU6q3'),
-            Row(s_name='Supplier#000000205', s_address='rF uV8d0JNEk'),
+            Row(s_name='Supplier#000000020', s_address='JtPqm19E7tF 152Rl1wQZ8j0H'),
+            Row(s_name='Supplier#000000091', s_address='35WVnU7GLNbQDcc2TARavGtk6RB6ZCd46UAY'),
+            Row(s_name='Supplier#000000205', s_address='Alrx5TN,hdnG'),
         ]
 
         with utilizes_valid_plans(spark_session):

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -360,7 +360,8 @@ class TestTpchWithDataFrameAPI:
             Row(c_custkey=143347, c_name='Customer#000143347', revenue=Decimal('721002.6948'),
                 c_acctbal=Decimal('2557.47'), n_name='EGYPT', c_address=',Q9Ml3w0gvX',
                 c_phone='14-742-935-3718',
-                c_comment='endencies sleep. slyly express deposits nag carefully around the even tithes. slyly regular '),
+                c_comment='endencies sleep. slyly express deposits nag carefully around the '
+                          'even tithes. slyly regular '),
         ]
 
         with utilizes_valid_plans(spark_session):


### PR DESCRIPTION
The DuckDB version uses Decimal which sidesteps float rounding issues (such
as that which affects query 15).
