### PR TITLE
feat: fix handling of datafusion local file renaming

### DIFF
--- a/src/backends/datafusion_backend.py
+++ b/src/backends/datafusion_backend.py
@@ -34,11 +34,8 @@ class DatafusionBackend(Backend):
         file_groups = ReplaceLocalFilesWithNamedTable().visit_plan(plan)
         registered_tables = set()
         for table_name, files in file_groups:
-            if len(files) == 1:
-                location = Path(files[0])
-            else:
-                # We can only register one location, so hope with the parent directory.
-                location = Path(files[0]).parent
+            # We can only register one location, so hope with the parent directory.
+            location = Path(files[0]) if len(files) == 1 else Path(files[0]).parent
             self.register_table(table_name, location)
             registered_tables.add(table_name)
 

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -144,10 +144,6 @@ def mark_dataframe_tests_as_xfail(request):
         pytest.skip(reason='missing in Substrait')
     if source == 'gateway-over-datafusion' and originalname == 'test_try_divide':
         pytest.skip(reason='returns infinity instead of null')
-    if source == 'gateway-over-datafusion' and originalname in ['test_data_source_schema',
-                                                                'test_data_source_filter',
-                                                                'test_data_source_options']:
-        pytest.skip(reason='list index out of range')
 
 
 # ruff: noqa: E712

--- a/src/gateway/tests/test_tpch_with_dataframe_api.py
+++ b/src/gateway/tests/test_tpch_with_dataframe_api.py
@@ -30,8 +30,6 @@ def mark_tests_as_xfail(request):
                 reason='Cannot create filter with non-boolean predicate - substr function'))
         elif originalname in ['test_query_11']:
             request.node.add_marker(pytest.mark.xfail(reason='Duplicate field in schema'))
-        elif originalname in ['test_query_15']:
-            request.node.add_marker(pytest.mark.xfail(reason='No results (float vs decimal)'))
 
 
 class TestTpchWithDataFrameAPI:

--- a/src/transforms/replace_local_files.py
+++ b/src/transforms/replace_local_files.py
@@ -11,6 +11,8 @@ from substrait_visitors.substrait_plan_visitor import SubstraitPlanVisitor
 class ReplaceLocalFilesWithNamedTable(SubstraitPlanVisitor):
     """Replaces all the local file instances with named tables."""
 
+    _TABLES_FOUND: int = 0
+
     def __init__(self):
         """Initialize the visitor."""
         self._file_groups: list[tuple[str, list[str]]] = []
@@ -23,7 +25,9 @@ class ReplaceLocalFilesWithNamedTable(SubstraitPlanVisitor):
         for item in local_files.items:
             files.append(item.uri_file)
         super().visit_local_files(local_files)
-        self._file_groups.append(('possible_table_name', files))
+        ReplaceLocalFilesWithNamedTable._TABLES_FOUND += 1
+        table_name = f'local_files_table{ReplaceLocalFilesWithNamedTable._TABLES_FOUND}'
+        self._file_groups.append((table_name, files))
 
     def visit_read_relation(self, rel: algebra_pb2.ReadRel) -> Any:
         """Visit a read relation node."""


### PR DESCRIPTION
The new TPC-H dataset consists of multiple, unrelated files in the same directory.
This updates the local file to virtual table rewrite code to handle that possibility.
