### PR TITLE
chore:  pin DuckDB to a specific version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
     - adbc_driver_manager
     - cargo
     - pyarrow >= 17.0.0
-    - duckdb >= 1.0.0
+    - duckdb == 1.0.*
     - datafusion == 40.1.*
     - grpcio-channelz
     - pyspark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name = "Substrait contributors", email = "substrait@googlegroups.com
 license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.8.1"
-dependencies = ["protobuf >= 3.20", "datafusion >= 40.1.0", "pyarrow >= 17.0.0", "substrait == 0.21.0"]
+dependencies = ["protobuf >= 3.20", "datafusion >= 40.1.0", "pyarrow >= 17.0.0", "substrait == 0.21.0", "duckdb == 1.0.*"]
 dynamic = ["version"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This should help prevent CI issues that will undoubtedly arise when the version is updated.
