### PR TITLE
feat: implement basic struct handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ or Velox.
 ### Locally
 To run the gateway locally - you need to setup a Python (Conda) environment.
 
+To run the Spark tests you will need Java installed.
+
 Ensure you have [Miniconda](https://docs.anaconda.com/miniconda/miniconda-install/) and [Rust/Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed.
 
 Once that is done - run these steps from a bash terminal:
 ```bash
-git clone --recursive https://github.com/<your-fork>/spark-substrait-gateway.git
+git clone https://github.com/<your-fork>/spark-substrait-gateway.git
 cd spark-substrait-gateway
 conda init bash
 . ~/.bashrc

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools >= 61.0.0
   - setuptools_scm >= 6.2.0
   - mypy-protobuf
-  - types-protobuf >= 4.25.0, < 5.0.0
+  - types-protobuf >= 5.0.0
   - numpy < 2.0.0
   - Faker
   - pip:
@@ -27,7 +27,7 @@ dependencies:
     - substrait == 0.21.0
     - substrait-validator
     - pytest-timeout
-    - protobuf >= 4.25.3, < 5.0.0
+    - protobuf >= 5.0.0
     - cryptography == 43.0.*
     - click == 8.1.*
     - pyjwt == 2.8.*

--- a/src/backends/arrow_tools.py
+++ b/src/backends/arrow_tools.py
@@ -7,6 +7,9 @@ def _reapply_names_to_type(array: pa.ChunkedArray, names: List[str]) -> (pa.Arra
     new_arrays = []
     new_schema = []
 
+    if array.type.num_fields > len(names):
+        raise ValueError('Insufficient number of names provided to reapply names.')
+
     remaining_names = names
     if pa.types.is_list(array.type):
         raise NotImplementedError('Reapplying names to lists not yet supported')

--- a/src/backends/arrow_tools.py
+++ b/src/backends/arrow_tools.py
@@ -1,0 +1,33 @@
+from typing import List
+
+import pyarrow as pa
+
+
+def _reapply_names_to_struct(struct: pa.StructArray, names: List[str]) -> pa.StructArray:
+    return struct
+
+
+def reapply_names(table: pa.Table, names: List[str]) -> pa.Table:
+    new_arrays = []
+    new_schema = []
+
+    for column in iter(table.columns):
+        # TODO: Rebuild the data.
+        # TODO: Save the schema.
+        pass
+
+    new_schema = pa.schema(
+        [
+            pa.field("test_struct", pa.struct([
+                pa.field("custid", pa.int64()),
+                pa.field("custname", pa.string()),
+            ])),
+        ]
+    )
+    custid_array = table.columns[0].chunks[0].field(0)
+    custname_array = table.columns[0].chunks[0].field(1)
+
+    new_struct_array = pa.StructArray.from_arrays([custid_array, custname_array], names=['custid', 'custname'])
+    new_table = pa.Table.from_arrays([new_struct_array], schema=new_schema)
+
+    return new_table

--- a/src/backends/arrow_tools.py
+++ b/src/backends/arrow_tools.py
@@ -3,31 +3,46 @@ from typing import List
 import pyarrow as pa
 
 
-def _reapply_names_to_struct(struct: pa.StructArray, names: List[str]) -> pa.StructArray:
-    return struct
+def _reapply_names_to_type(array: pa.ChunkedArray, names: List[str]) -> (pa.Array, List[str]):
+    new_arrays = []
+    new_schema = []
+
+    remaining_names = names
+    if pa.types.is_list(array.type):
+        raise NotImplementedError('Reapplying names to lists not yet supported')
+    elif pa.types.is_map(array.type):
+        raise NotImplementedError('Reapplying names to maps not yet supported')
+    elif pa.types.is_struct(array.type):
+        field_num = 0
+        while field_num < array.type.num_fields:
+            field = array.chunks[0].field(field_num)
+            this_name = remaining_names.pop(0)
+
+            new_array, remaining_names = _reapply_names_to_type(field, remaining_names)
+            new_arrays.append(new_array)
+
+            new_schema.append(pa.field(this_name, new_array.type))
+
+            field_num += 1
+
+        return pa.StructArray.from_arrays(new_arrays, fields=new_schema), remaining_names
+    if array.type.num_fields != 0:
+        raise ValueError(f'Unsupported complex type: {array.type}')
+    return array, remaining_names
 
 
 def reapply_names(table: pa.Table, names: List[str]) -> pa.Table:
     new_arrays = []
     new_schema = []
 
+    remaining_names = names
     for column in iter(table.columns):
-        # TODO: Rebuild the data.
-        # TODO: Save the schema.
-        pass
+        this_name = remaining_names.pop(0)
 
-    new_schema = pa.schema(
-        [
-            pa.field("test_struct", pa.struct([
-                pa.field("custid", pa.int64()),
-                pa.field("custname", pa.string()),
-            ])),
-        ]
-    )
-    custid_array = table.columns[0].chunks[0].field(0)
-    custname_array = table.columns[0].chunks[0].field(1)
+        new_array, remaining_names = _reapply_names_to_type(column, remaining_names)
+        new_arrays.append(new_array)
 
-    new_struct_array = pa.StructArray.from_arrays([custid_array, custname_array], names=['custid', 'custname'])
-    new_table = pa.Table.from_arrays([new_struct_array], schema=new_schema)
+        new_schema.append(pa.field(this_name, new_array.type))
 
+    new_table = pa.Table.from_arrays(new_arrays, schema=pa.schema(new_schema))
     return new_table

--- a/src/backends/arrow_tools.py
+++ b/src/backends/arrow_tools.py
@@ -41,11 +41,17 @@ def reapply_names(table: pa.Table, names: list[str]) -> pa.Table:
 
     remaining_names = names
     for column in iter(table.columns):
+        if not remaining_names:
+            raise ValueError('Insufficient number of names provided to reapply names.')
+
         this_name = remaining_names.pop(0)
 
         new_array, remaining_names = _reapply_names_to_type(column, remaining_names)
         new_arrays.append(new_array)
 
         new_schema.append(pa.field(this_name, new_array.type))
+
+    if remaining_names:
+        raise ValueError('Too many names provided to reapply names.')
 
     return pa.Table.from_arrays(new_arrays, schema=pa.schema(new_schema))

--- a/src/backends/arrow_tools.py
+++ b/src/backends/arrow_tools.py
@@ -1,9 +1,9 @@
-from typing import List
-
+# SPDX-License-Identifier: Apache-2.0
+"""Routines to manipulate arrow tables."""
 import pyarrow as pa
 
 
-def _reapply_names_to_type(array: pa.ChunkedArray, names: List[str]) -> (pa.Array, List[str]):
+def _reapply_names_to_type(array: pa.ChunkedArray, names: list[str]) -> (pa.Array, list[str]):
     new_arrays = []
     new_schema = []
 
@@ -13,9 +13,9 @@ def _reapply_names_to_type(array: pa.ChunkedArray, names: List[str]) -> (pa.Arra
     remaining_names = names
     if pa.types.is_list(array.type):
         raise NotImplementedError('Reapplying names to lists not yet supported')
-    elif pa.types.is_map(array.type):
+    if pa.types.is_map(array.type):
         raise NotImplementedError('Reapplying names to maps not yet supported')
-    elif pa.types.is_struct(array.type):
+    if pa.types.is_struct(array.type):
         field_num = 0
         while field_num < array.type.num_fields:
             field = array.chunks[0].field(field_num)
@@ -34,7 +34,8 @@ def _reapply_names_to_type(array: pa.ChunkedArray, names: List[str]) -> (pa.Arra
     return array, remaining_names
 
 
-def reapply_names(table: pa.Table, names: List[str]) -> pa.Table:
+def reapply_names(table: pa.Table, names: list[str]) -> pa.Table:
+    """Apply the provided names to the given table recursively."""
     new_arrays = []
     new_schema = []
 
@@ -47,5 +48,4 @@ def reapply_names(table: pa.Table, names: List[str]) -> pa.Table:
 
         new_schema.append(pa.field(this_name, new_array.type))
 
-    new_table = pa.Table.from_arrays(new_arrays, schema=pa.schema(new_schema))
-    return new_table
+    return pa.Table.from_arrays(new_arrays, schema=pa.schema(new_schema))

--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -71,6 +71,7 @@ class DuckDBBackend(Backend):
     def _execute_plan(self, plan: plan_pb2.Plan) -> pa.lib.Table:
         """Execute the given Substrait plan against DuckDB."""
         if True:
+            # MEGAHACK -- Modify the plan conversion to include these fields.
             plan.relations[0].root.names.append("custid")
             plan.relations[0].root.names.append("custname")
         plan_data = plan.SerializeToString()

--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -4,7 +4,6 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List
 
 import duckdb
 import pyarrow as pa
@@ -12,9 +11,8 @@ import pyarrow.parquet as pq
 from substrait.gen.proto import plan_pb2
 
 from backends.backend import Backend
-from transforms.rename_functions import RenameFunctionsForDuckDB
-
 from src.backends.arrow_tools import reapply_names
+from transforms.rename_functions import RenameFunctionsForDuckDB
 
 
 # pylint: disable=fixme

--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -67,13 +67,30 @@ class DuckDBBackend(Backend):
     # ruff: noqa: BLE001
     def _execute_plan(self, plan: plan_pb2.Plan) -> pa.lib.Table:
         """Execute the given Substrait plan against DuckDB."""
+        if False:
+            plan.relations[0].root.names.append("custid")
+            plan.relations[0].root.names.append("custname")
         plan_data = plan.SerializeToString()
 
         try:
             query_result = self._connection.from_substrait(proto=plan_data)
         except Exception as err:
             raise ValueError(f"DuckDB Execution Error: {err}") from err
-        return query_result.arrow()
+        if False:
+            arrow = query_result.arrow()
+            new_struct_array = pa.StructArray.from_arrays(arrow, names=["custid", "custname"])
+            new_schema = pa.schema(
+                [
+                    pa.field("test_struct", pa.struct([
+                        pa.field("custid", pa.int64()),
+                        pa.field("custname", pa.string()),
+                    ])),
+                ]
+            )
+            new_table = pa.Table.from_arrays([new_struct_array], schema=new_schema)
+            return new_table
+        else:
+            return query_result.arrow()
 
     def register_table(
         self,

--- a/src/backends/duckdb_backend.py
+++ b/src/backends/duckdb_backend.py
@@ -70,10 +70,6 @@ class DuckDBBackend(Backend):
     # ruff: noqa: BLE001
     def _execute_plan(self, plan: plan_pb2.Plan) -> pa.lib.Table:
         """Execute the given Substrait plan against DuckDB."""
-        if True:
-            # MEGAHACK -- Modify the plan conversion to include these fields.
-            plan.relations[0].root.names.append("custid")
-            plan.relations[0].root.names.append("custname")
         plan_data = plan.SerializeToString()
 
         try:

--- a/src/backends/tests/arrow_tools_test.py
+++ b/src/backends/tests/arrow_tools_test.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import List
+import pytest
+import pyarrow as pa
+
+from src.backends.arrow_tools import reapply_names
+
+
+@dataclass
+class TestCase:
+    name: str
+    input: pa.Table
+    names: List[str]
+    expected: pa.table
+
+
+cases: List[TestCase] = [
+    TestCase('empty table', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    TestCase('normal columns', pa.Table.from_arrays([]), ['a', 'b', 'c'], pa.Table.from_arrays([])),
+    TestCase('struct column', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    TestCase('nested structs', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+]
+
+
+class TestArrowTools:
+    """Tests the functionality of the arrow tools package."""
+
+    @pytest.mark.parametrize(
+        "case", cases, ids=lambda case: case.name
+    )
+    def test_reapply_names(self, case):
+        result = reapply_names(case.input, case.names)
+        assert result == case.expected

--- a/src/backends/tests/arrow_tools_test.py
+++ b/src/backends/tests/arrow_tools_test.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
-from typing import List
-import pytest
+
 import pyarrow as pa
+import pytest
 
 from src.backends.arrow_tools import reapply_names
 
@@ -10,11 +11,11 @@ from src.backends.arrow_tools import reapply_names
 class TestCase:
     name: str
     input: pa.Table
-    names: List[str]
+    names: list[str]
     expected: pa.table
 
 
-cases: List[TestCase] = [
+cases: list[TestCase] = [
     TestCase('empty table', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
     TestCase('normal columns',
              pa.Table.from_pydict(
@@ -23,16 +24,19 @@ cases: List[TestCase] = [
              ),
              ['renamed_name', 'renamed_age'],
              pa.Table.from_pydict(
-                 {"renamed_name": [None, "Joe", "Sarah", None], "renamed_age": [99, None, 42, None]},
+                 {"renamed_name": [None, "Joe", "Sarah", None],
+                  "renamed_age": [99, None, 42, None]},
                  schema=pa.schema({"renamed_name": pa.string(), "renamed_age": pa.int32()})
              )),
     TestCase('struct column',
              pa.Table.from_arrays(
-                 [pa.array([{"": 1, "b": "b"}], type=pa.struct([("", pa.int64()), ("b", pa.string())]))],
+                 [pa.array([{"": 1, "b": "b"}],
+                           type=pa.struct([("", pa.int64()), ("b", pa.string())]))],
                  names=["r"]),
              ['r', 'a', 'b'],
              pa.Table.from_arrays(
-                 [pa.array([{"a": 1, "b": "b"}], type=pa.struct([("a", pa.int64()), ("b", pa.string())]))], names=["r"])
+                 [pa.array([{"a": 1, "b": "b"}],
+                           type=pa.struct([("a", pa.int64()), ("b", pa.string())]))], names=["r"])
              ),
     TestCase('nested structs', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
     # TODO -- Test a list.

--- a/src/backends/tests/arrow_tools_test.py
+++ b/src/backends/tests/arrow_tools_test.py
@@ -13,10 +13,13 @@ class TestCase:
     input: pa.Table
     names: list[str]
     expected: pa.table
+    fail: bool = False
 
 
 cases: list[TestCase] = [
-    TestCase('empty table', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    TestCase('empty table', pa.Table.from_arrays([]), [], pa.Table.from_arrays([])),
+    TestCase('too many names', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([]),
+             fail=True),
     TestCase('normal columns',
              pa.Table.from_pydict(
                  {"name": [None, "Joe", "Sarah", None], "age": [99, None, 42, None]},
@@ -28,6 +31,18 @@ cases: list[TestCase] = [
                   "renamed_age": [99, None, 42, None]},
                  schema=pa.schema({"renamed_name": pa.string(), "renamed_age": pa.int32()})
              )),
+    TestCase('too few names',
+             pa.Table.from_pydict(
+                 {"name": [None, "Joe", "Sarah", None], "age": [99, None, 42, None]},
+                 schema=pa.schema({"name": pa.string(), "age": pa.int32()})
+             ),
+             ['renamed_name'],
+             pa.Table.from_pydict(
+                 {"renamed_name": [None, "Joe", "Sarah", None],
+                  "renamed_age": [99, None, 42, None]},
+                 schema=pa.schema({"renamed_name": pa.string(), "renamed_age": pa.int32()})
+             ),
+             fail=True),
     TestCase('struct column',
              pa.Table.from_arrays(
                  [pa.array([{"": 1, "b": "b"}],
@@ -38,13 +53,14 @@ cases: list[TestCase] = [
                  [pa.array([{"a": 1, "b": "b"}],
                            type=pa.struct([("a", pa.int64()), ("b", pa.string())]))], names=["r"])
              ),
-    TestCase('nested structs', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    # TODO -- Test nested structs.
     # TODO -- Test a list.
     # TODO -- Test a map.
     # TODO -- Test a mixture of complex and simple types.
 ]
 
 
+@pytest.mark.interesting
 class TestArrowTools:
     """Tests the functionality of the arrow tools package."""
 
@@ -52,5 +68,14 @@ class TestArrowTools:
         "case", cases, ids=lambda case: case.name
     )
     def test_reapply_names(self, case):
-        result = reapply_names(case.input, case.names)
-        assert result == case.expected
+        failed = False
+        try:
+            result = reapply_names(case.input, case.names)
+        except ValueError as _:
+            result = None
+            failed = True
+        if case.fail:
+            assert failed
+        else:
+            assert result == case.expected
+

--- a/src/backends/tests/arrow_tools_test.py
+++ b/src/backends/tests/arrow_tools_test.py
@@ -16,9 +16,28 @@ class TestCase:
 
 cases: List[TestCase] = [
     TestCase('empty table', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
-    TestCase('normal columns', pa.Table.from_arrays([]), ['a', 'b', 'c'], pa.Table.from_arrays([])),
-    TestCase('struct column', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    TestCase('normal columns',
+             pa.Table.from_pydict(
+                 {"name": [None, "Joe", "Sarah", None], "age": [99, None, 42, None]},
+                 schema=pa.schema({"name": pa.string(), "age": pa.int32()})
+             ),
+             ['renamed_name', 'renamed_age'],
+             pa.Table.from_pydict(
+                 {"renamed_name": [None, "Joe", "Sarah", None], "renamed_age": [99, None, 42, None]},
+                 schema=pa.schema({"renamed_name": pa.string(), "renamed_age": pa.int32()})
+             )),
+    TestCase('struct column',
+             pa.Table.from_arrays(
+                 [pa.array([{"": 1, "b": "b"}], type=pa.struct([("", pa.int64()), ("b", pa.string())]))],
+                 names=["r"]),
+             ['r', 'a', 'b'],
+             pa.Table.from_arrays(
+                 [pa.array([{"a": 1, "b": "b"}], type=pa.struct([("a", pa.int64()), ("b", pa.string())]))], names=["r"])
+             ),
     TestCase('nested structs', pa.Table.from_arrays([]), ['a', 'b'], pa.Table.from_arrays([])),
+    # TODO -- Test a list.
+    # TODO -- Test a map.
+    # TODO -- Test a mixture of complex and simple types.
 ]
 
 

--- a/src/backends/tests/arrow_tools_test.py
+++ b/src/backends/tests/arrow_tools_test.py
@@ -60,7 +60,6 @@ cases: list[TestCase] = [
 ]
 
 
-@pytest.mark.interesting
 class TestArrowTools:
     """Tests the functionality of the arrow tools package."""
 

--- a/src/gateway/converter/conversion_options.py
+++ b/src/gateway/converter/conversion_options.py
@@ -11,7 +11,7 @@ from backends.backend_options import BackendEngine, BackendOptions
 class ConversionOptions:
     """Holds all the possible conversion options."""
 
-    def __init__(self, backend: BackendOptions = None):
+    def __init__(self, backend: BackendOptions):
         """Initialize the conversion options."""
         self.use_named_table_workaround = False
         self.needs_scheme_in_path_uris = False

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -786,17 +786,16 @@ class SparkSubstraitConverter:
                 value=self.convert_unresolved_attribute(extract.child.unresolved_attribute)
             )
         )
-        # MEGAHACK -- here
-        # MEGAHACK -- Fix this to be relative to the struct value we found above.
         field_ref = self.find_field_by_name(extract.extraction.literal.string)
         if field_ref is None:
-            raise ValueError(
-                f"could not locate field named {extract.extraction.literal.string} in plan id "
-                f"{self._current_plan_id}"
+            func.arguments.append(
+                algebra_pb2.FunctionArgument(value=string_literal(extract.extraction.literal.string))
             )
-        func.arguments.append(
-            algebra_pb2.FunctionArgument(value=integer_literal(field_ref + 1))
-        )
+        else:
+            # TODO -- Fix this to be relative to the struct value we found above.
+            func.arguments.append(
+                algebra_pb2.FunctionArgument(value=integer_literal(field_ref + 1))
+            )
         return algebra_pb2.Expression(scalar_function=func)
 
     def convert_expression(self, expr: spark_exprs_pb2.Expression) -> algebra_pb2.Expression | None:

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1860,7 +1860,7 @@ class SparkSubstraitConverter:
         if not symbol:
             raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         for field_name in plan.relations[0].root.names:
-            symbol.output_fields.append(field_name)
+            symbol.output_fields.append(Field(field_name))
         # TODO -- Correctly capture all the used functions and extensions.
         self._saved_extension_uris = plan.extension_uris
         self._saved_extensions = plan.extensions

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -57,7 +57,11 @@ from gateway.converter.substrait_builder import (
     string_type,
     strlen,
 )
-from gateway.converter.symbol_table import SymbolTable
+from gateway.converter.symbol_table import Field, SymbolTable
+
+
+class InternalError(Exception):
+    pass
 
 
 class ExpressionProcessingMode(Enum):
@@ -81,6 +85,13 @@ def _extract_decimal_parameters(type_name: str) -> tuple[int, int, int]:
     return int(match.group(1)), int(match.group(2)), int(match.group(3))
 
 
+def _find_reference_number(fields: list[Field], name: str) -> int | None:
+    for reference, field in enumerate(fields):
+        if field.name == name:
+            return reference
+    return None
+
+
 # ruff: noqa: RUF005
 class SparkSubstraitConverter:
     """Converts SparkConnect plans to Substrait plans."""
@@ -101,7 +112,7 @@ class SparkSubstraitConverter:
         # These are used when processing expressions inside aggregate relations.
         self._expression_processing_mode = ExpressionProcessingMode.NORMAL
         self._top_level_projects: list[algebra_pb2.Rel] = []
-        self._next_aggregation_reference_id = None
+        self._next_aggregation_reference_id = 0
         self._aggregations: list[algebra_pb2.AggregateFunction] = []
         self._next_under_aggregation_reference_id = 0
         self._under_aggregation_projects: list[algebra_pb2.Rel] = []
@@ -114,8 +125,9 @@ class SparkSubstraitConverter:
 
     def lookup_function_by_name(self, name: str) -> ExtensionFunction:
         """Find the function reference for a given Spark function name."""
-        if name in self._functions:
-            return self._functions.get(name)
+        function = self._functions.get(name)
+        if function is not None:
+            return function
         func = lookup_spark_function(name, self._conversion_options)
         if not func:
             raise LookupError(
@@ -125,25 +137,33 @@ class SparkSubstraitConverter:
         self._functions[name] = func
         if not self._function_uris.get(func.uri):
             self._function_uris[func.uri] = len(self._function_uris) + 1
-        return self._functions.get(name)
+        function = self._functions.get(name)
+        assert function is not None
+        return function
 
     def update_field_references(self, plan_id: int) -> None:
         """Use the field references using the specified portion of the plan."""
         source_symbol = self._symbol_table.get_symbol(plan_id)
+        if not source_symbol:
+            raise InternalError(f'Could not find plan id {plan_id} that we constructed earlier.')
         current_symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not current_symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         original_output_fields = current_symbol.output_fields
         for symbol in source_symbol.output_fields:
-            new_name = symbol
-            while new_name in original_output_fields:
-                new_name = new_name + "_dup"
-            current_symbol.input_fields.append(new_name)
-            current_symbol.output_fields.append(new_name)
+            new_symbol = symbol
+            while _find_reference_number(original_output_fields, new_symbol.name):
+                new_symbol.name = new_symbol.name + "_dup"
+            current_symbol.input_fields.append(new_symbol)
+            current_symbol.output_fields.append(new_symbol)
 
     def find_field_by_name(self, field_name: str) -> int | None:
         """Look up the field name in the current set of field references."""
         current_symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not current_symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         try:
-            return current_symbol.input_fields.index(field_name)
+            return _find_reference_number(current_symbol.input_fields, field_name)
         except ValueError:
             return None
 
@@ -172,7 +192,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression.Literal(string=s)
 
     def convert_literal_expression(
-        self, literal: spark_exprs_pb2.Expression.Literal
+            self, literal: spark_exprs_pb2.Expression.Literal
     ) -> algebra_pb2.Expression:
         """Convert a Spark literal into a Substrait literal."""
         match literal.WhichOneof("literal_type"):
@@ -251,7 +271,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression(literal=result)
 
     def convert_unresolved_attribute(
-        self, attr: spark_exprs_pb2.Expression.UnresolvedAttribute
+            self, attr: spark_exprs_pb2.Expression.UnresolvedAttribute
     ) -> algebra_pb2.Expression:
         """Convert a Spark unresolved attribute into a Substrait field reference."""
         field_ref = self.find_field_by_name(attr.unparsed_identifier)
@@ -308,7 +328,7 @@ class SparkSubstraitConverter:
         )
 
     def convert_when_function(
-        self, when: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, when: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark when function into a Substrait if-then expression."""
         ifthen = algebra_pb2.Expression.IfThen()
@@ -324,6 +344,8 @@ class SparkSubstraitConverter:
         else:
             nullable_literal = self.determine_type_of_expression(ifthen.ifs[-1].then)
             kind = nullable_literal.WhichOneof("kind")
+            if not kind:
+                raise ValueError('Missing kind one_of in when function.')
             getattr(
                 nullable_literal, kind
             ).nullability = type_pb2.Type.Nullability.NULLABILITY_NULLABLE
@@ -336,7 +358,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression(if_then=ifthen)
 
     def convert_in_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark in function into a Substrait switch expression."""
 
@@ -378,7 +400,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression(if_then=ifthen)
 
     def convert_rlike_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark rlike function into a Substrait expression."""
         if self._conversion_options.use_duckdb_regexp_matches_function:
@@ -419,7 +441,7 @@ class SparkSubstraitConverter:
         return greater_function(greater_func, regexp_expr, bigint_literal(0))
 
     def convert_nanvl_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark nanvl function into a Substrait expression."""
         isnan_func = self.lookup_function_by_name("isnan")
@@ -438,7 +460,7 @@ class SparkSubstraitConverter:
         return if_then_else_operation(expr, arg1, arg0)
 
     def convert_nvl_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark nvl function into a Substrait expression."""
         isnull_func = self.lookup_function_by_name("isnull")
@@ -457,7 +479,7 @@ class SparkSubstraitConverter:
         return if_then_else_operation(expr, arg1, arg0)
 
     def convert_nvl2_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark nvl2 function into a Substrait expression."""
         isnotnull_func = self.lookup_function_by_name("isnotnull")
@@ -477,7 +499,7 @@ class SparkSubstraitConverter:
         return if_then_else_operation(expr, arg1, arg2)
 
     def convert_ifnull_function(
-        self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, in_: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark ifnull function into a Substrait expression."""
         isnan_func = self.lookup_function_by_name("isnull")
@@ -496,7 +518,7 @@ class SparkSubstraitConverter:
         return if_then_else_operation(expr, arg1, arg0)
 
     def convert_struct_function(
-        self, func: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, func: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression:
         """Convert a Spark struct function into a Substrait nested expression."""
         nested = algebra_pb2.Expression.Nested()
@@ -507,7 +529,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression(nested=nested)
 
     def convert_unresolved_function(
-        self, unresolved_function: spark_exprs_pb2.Expression.UnresolvedFunction
+            self, unresolved_function: spark_exprs_pb2.Expression.UnresolvedFunction
     ) -> algebra_pb2.Expression | algebra_pb2.AggregateFunction:
         """Convert a Spark unresolved function into a Substrait scalar function."""
         parent_processing_mode = self._expression_processing_mode
@@ -533,8 +555,8 @@ class SparkSubstraitConverter:
             func = algebra_pb2.Expression.ScalarFunction()
             function_def = self.lookup_function_by_name(unresolved_function.function_name)
             if (
-                parent_processing_mode == ExpressionProcessingMode.AGGR_NOT_TOP_LEVEL
-                and function_def.function_type == FunctionType.AGGREGATE
+                    parent_processing_mode == ExpressionProcessingMode.AGGR_NOT_TOP_LEVEL
+                    and function_def.function_type == FunctionType.AGGREGATE
             ):
                 self._expression_processing_mode = ExpressionProcessingMode.AGGR_UNDER_AGGREGATE
             func.function_reference = function_def.anchor
@@ -542,8 +564,8 @@ class SparkSubstraitConverter:
                 if function_def.max_args is not None and idx >= function_def.max_args:
                     break
                 if (
-                    unresolved_function.function_name == "count"
-                    and arg.WhichOneof("expr_type") == "unresolved_star"
+                        unresolved_function.function_name == "count"
+                        and arg.WhichOneof("expr_type") == "unresolved_star"
                 ):
                     # Ignore all the rest of the arguments.
                     func.arguments.append(algebra_pb2.FunctionArgument(value=bigint_literal(1)))
@@ -589,7 +611,7 @@ class SparkSubstraitConverter:
             self._expression_processing_mode = parent_processing_mode
 
     def convert_alias_expression(
-        self, alias: spark_exprs_pb2.Expression.Alias
+            self, alias: spark_exprs_pb2.Expression.Alias
     ) -> algebra_pb2.Expression:
         """Convert a Spark alias into a Substrait expression."""
         # We do nothing here and let the magic happen in the calling project relation.
@@ -620,7 +642,7 @@ class SparkSubstraitConverter:
         return self.convert_type_str(spark_type.WhichOneof("kind"))
 
     def convert_cast_expression(
-        self, cast: spark_exprs_pb2.Expression.Cast
+            self, cast: spark_exprs_pb2.Expression.Cast
     ) -> algebra_pb2.Expression:
         """Convert a Spark cast expression into a Substrait cast expression."""
         cast_rel = algebra_pb2.Expression.Cast(
@@ -752,7 +774,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Expression(window_function=func)
 
     def convert_extract_value(
-        self, extract: spark_exprs_pb2.Expression.UnresolvedExtractValue
+            self, extract: spark_exprs_pb2.Expression.UnresolvedExtractValue
     ) -> algebra_pb2.Expression:
         """Convert a Spark extract value expression into a Substrait extract value expression."""
         # TODO -- Add support for list and map operations.
@@ -764,6 +786,7 @@ class SparkSubstraitConverter:
                 value=self.convert_unresolved_attribute(extract.child.unresolved_attribute)
             )
         )
+        # MEGAHACK -- here
         # MEGAHACK -- Fix this to be relative to the struct value we found above.
         field_ref = self.find_field_by_name(extract.extraction.literal.string)
         if field_ref is None:
@@ -772,7 +795,7 @@ class SparkSubstraitConverter:
                 f"{self._current_plan_id}"
             )
         func.arguments.append(
-            algebra_pb2.FunctionArgument(value=integer_literal(field_ref+1))
+            algebra_pb2.FunctionArgument(value=integer_literal(field_ref + 1))
         )
         return algebra_pb2.Expression(scalar_function=func)
 
@@ -861,21 +884,25 @@ class SparkSubstraitConverter:
         return primary_names
 
     def convert_read_named_table_relation(
-        self, rel: spark_relations_pb2.Read.NamedTable
+            self, rel: spark_relations_pb2.Read.NamedTable
     ) -> algebra_pb2.Rel:
         """Convert a read named table relation to a Substrait relation."""
         table_name = rel.unparsed_identifier
 
+        assert self._backend is not None
         arrow_schema = self._backend.describe_table(table_name)
 
         schema = self.convert_arrow_schema(arrow_schema)
 
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         if self._conversion_options.use_duckdb_struct_name_behavior:
             for field_name in self.get_primary_names(schema):
-                symbol.output_fields.append(field_name)
+                symbol.output_fields.append(Field(field_name))
         else:
-            symbol.output_fields.extend(schema.names)
+            for field_name in schema.names:
+                symbol.output_fields.append(Field(field_name))
 
         return algebra_pb2.Rel(
             read=algebra_pb2.ReadRel(
@@ -912,7 +939,7 @@ class SparkSubstraitConverter:
             case _:
                 raise NotImplementedError(f"Unexpected type name: {type_name}")
 
-    def convert_field(self, field: types_pb2.DataType) -> (type_pb2.Type, list[str]):
+    def convert_field(self, field: types_pb2.DataType) -> tuple[type_pb2.Type, list[str]]:
         """Convert a Spark field into a Substrait field."""
         if field.get("nullable"):
             nullability = type_pb2.Type.NULLABILITY_NULLABLE
@@ -960,6 +987,8 @@ class SparkSubstraitConverter:
                 elif ft.get("type") == "struct":
                     field_type = type_pb2.Type(struct=type_pb2.Type.Struct(nullability=nullability))
                     sub_type = self.convert_schema_dict(ft)
+                    if not sub_type:
+                        raise ValueError(f'Could not parse type struct type {ft}')
                     more_names.extend(sub_type.names)
                     field_type.struct.types.extend(sub_type.struct.types)
                 else:
@@ -990,8 +1019,8 @@ class SparkSubstraitConverter:
         return self.convert_schema_dict(schema_data)
 
     def convert_arrow_datatype(
-        self, arrow_type: pa.DataType, nullable: bool = False
-    ) -> (type_pb2.Type, list[str]):
+            self, arrow_type: pa.DataType, nullable: bool = False
+    ) -> tuple[type_pb2.Type, list[str]]:
         """Convert an Arrow datatype into a Substrait type."""
         if nullable:
             nullability = type_pb2.Type.NULLABILITY_NULLABLE
@@ -1032,7 +1061,7 @@ class SparkSubstraitConverter:
                         sub_type = self.convert_arrow_schema(y.type.schema)
                         more_names.extend(y.name)
                         field_type.struct.types.extend(sub_type.struct.types)
-                    return field_type
+                    return field_type, more_names
                 raise NotImplementedError(f"Unexpected arrow datatype: {arrow_type}")
 
         return field_type, more_names
@@ -1125,8 +1154,10 @@ class SparkSubstraitConverter:
             arrow_schema = self._backend.describe_files(paths)
             schema = self.convert_arrow_schema(arrow_schema)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         for field_name in schema.names:
-            symbol.output_fields.append(field_name)
+            symbol.output_fields.append(Field(field_name))
         if self._conversion_options.use_named_table_workaround:
             return algebra_pb2.Rel(
                 read=algebra_pb2.ReadRel(
@@ -1195,6 +1226,8 @@ class SparkSubstraitConverter:
         if not self._conversion_options.use_emits_instead_of_direct:
             return algebra_pb2.RelCommon(direct=algebra_pb2.RelCommon.Direct())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         emit = algebra_pb2.RelCommon.Emit()
         if emit_overrides:
             for field_number in emit_overrides:
@@ -1277,6 +1310,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         aggregate.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
 
         # Start tracking the parts of the expressions we are interested in.
         self._top_level_projects = []
@@ -1352,7 +1387,7 @@ class SparkSubstraitConverter:
             result = self.convert_expression(expr)
             if result:
                 self._top_level_projects.append(result)
-            symbol.generated_fields.append(self.determine_expression_name(expr))
+            symbol.generated_fields.append(Field(self.determine_expression_name(expr)))
         symbol.output_fields.clear()
         symbol.output_fields.extend(symbol.generated_fields)
         if len(rel.grouping_expressions) > 1:
@@ -1458,6 +1493,8 @@ class SparkSubstraitConverter:
         # Now that we've processed the input, do the bookkeeping.
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
 
         # Find the length of each column in every row.
         project1 = project_relation(
@@ -1486,18 +1523,18 @@ class SparkSubstraitConverter:
                     least_function(
                         greater_func, field_reference(column_number), bigint_literal(rel.truncate)
                     ),
-                    strlen(strlen_func, string_literal(symbol.input_fields[column_number])),
+                    strlen(strlen_func, string_literal(symbol.input_fields[column_number].name)),
                 )
                 for column_number in range(len(symbol.input_fields))
             ],
         )
 
-        def field_header_fragment(field_number: int) -> list[algebra_pb2.Expression]:
+        def field_header_fragment(fields: list[Field], field_number: int) -> list[algebra_pb2.Expression]:
             return [
                 string_literal("|"),
                 lpad_function(
                     lpad_func,
-                    string_literal(symbol.input_fields[field_number]),
+                    string_literal(fields[field_number].name),
                     field_reference(field_number),
                 ),
             ]
@@ -1508,7 +1545,7 @@ class SparkSubstraitConverter:
                 repeat_function(repeat_func, "-", field_reference(field_number)),
             ]
 
-        def field_body_fragment(field_number: int) -> list[algebra_pb2.Expression]:
+        def field_body_fragment(fields: list[Field], field_number: int) -> list[algebra_pb2.Expression]:
             return [
                 string_literal("|"),
                 if_then_else_operation(
@@ -1518,7 +1555,7 @@ class SparkSubstraitConverter:
                             strlen_func,
                             cast_operation(field_reference(field_number), string_type()),
                         ),
-                        field_reference(field_number + len(symbol.input_fields)),
+                        field_reference(field_number + len(fields)),
                     ),
                     concat(
                         concat_func,
@@ -1528,7 +1565,7 @@ class SparkSubstraitConverter:
                                 field_reference(field_number),
                                 minus_function(
                                     minus_func,
-                                    field_reference(field_number + len(symbol.input_fields)),
+                                    field_reference(field_number + len(fields)),
                                     bigint_literal(3),
                                 ),
                             ),
@@ -1538,17 +1575,17 @@ class SparkSubstraitConverter:
                     lpad_function(
                         lpad_func,
                         field_reference(field_number),
-                        field_reference(field_number + len(symbol.input_fields)),
+                        field_reference(field_number + len(fields)),
                     ),
                 ),
             ]
 
-        def header_line(fields: list[str]) -> list[algebra_pb2.Expression]:
+        def header_line(fields: list[Field]) -> list[algebra_pb2.Expression]:
             return [
                 concat(
                     concat_func,
                     flatten(
-                        [field_header_fragment(field_number) for field_number in range(len(fields))]
+                        [field_header_fragment(fields, field_number) for field_number in range(len(fields))]
                     )
                     + [
                         string_literal("|\n"),
@@ -1556,7 +1593,7 @@ class SparkSubstraitConverter:
                 )
             ]
 
-        def full_line(fields: list[str]) -> list[algebra_pb2.Expression]:
+        def full_line(fields: list[Field]) -> list[algebra_pb2.Expression]:
             return [
                 concat(
                     concat_func,
@@ -1594,7 +1631,7 @@ class SparkSubstraitConverter:
                     concat_func,
                     flatten(
                         [
-                            field_body_fragment(field_number)
+                            field_body_fragment(symbol.input_fields, field_number)
                             for field_number in range(len(symbol.input_fields))
                         ]
                     )
@@ -1614,8 +1651,10 @@ class SparkSubstraitConverter:
         join2 = join_relation(project3, aggregate2)
 
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         symbol.output_fields.clear()
-        symbol.output_fields.append("show_string")
+        symbol.output_fields.append(Field("show_string"))
 
         def compute_row_count_footer(num_rows: int) -> str:
             if num_rows == 1:
@@ -1647,26 +1686,29 @@ class SparkSubstraitConverter:
         return project5
 
     def convert_with_columns_relation(
-        self, rel: spark_relations_pb2.WithColumns
+            self, rel: spark_relations_pb2.WithColumns
     ) -> algebra_pb2.Rel:
         """Convert a with columns relation into a Substrait project relation."""
         input_rel = self.convert_relation(rel.input)
         project = algebra_pb2.ProjectRel(input=input_rel)
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         proposed_expressions = [field_reference(i) for i in range(len(symbol.input_fields))]
         for alias in rel.aliases:
             if len(alias.name) != 1:
                 raise ValueError("Only one name part is supported in an alias.")
             name = alias.name[0]
-            if name in symbol.input_fields:
-                proposed_expressions[symbol.input_fields.index(name)] = self.convert_expression(
-                    alias.expr
-                )
+            field_num = _find_reference_number(symbol.input_fields, name)
+            if field_num is not None:
+                # Overwrite our the old expression with our own.
+                proposed_expressions[field_num] = self.convert_expression(alias.expr)
             else:
+                # This is a new column.
                 proposed_expressions.append(self.convert_expression(alias.expr))
-                symbol.generated_fields.append(name)
-                symbol.output_fields.append(name)
+                symbol.generated_fields.append(Field(name))
+                symbol.output_fields.append(Field(name))
         project.common.CopyFrom(self.create_common_relation())
         project.expressions.extend(proposed_expressions)
         for i in range(len(proposed_expressions)):
@@ -1674,22 +1716,24 @@ class SparkSubstraitConverter:
         return algebra_pb2.Rel(project=project)
 
     def convert_with_columns_renamed_relation(
-        self, rel: spark_relations_pb2.WithColumnsRenamed
+            self, rel: spark_relations_pb2.WithColumnsRenamed
     ) -> algebra_pb2.Rel:
         """Update the columns names based on the Spark with columns renamed relation."""
         input_rel = self.convert_relation(rel.input)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         self.update_field_references(rel.input.common.plan_id)
         symbol.output_fields.clear()
         if hasattr(rel, "renames"):
             aliases = {r.col_name: r.new_col_name for r in rel.renames}
         else:
             aliases = rel.rename_columns_map
-        for field_name in symbol.input_fields:
-            if field_name in aliases:
-                symbol.output_fields.append(aliases[field_name])
+        for field in symbol.input_fields:
+            if field.name in aliases:
+                symbol.output_fields.append(field.alias(aliases[field.name]))
             else:
-                symbol.output_fields.append(field_name)
+                symbol.output_fields.append(field)
         return input_rel
 
     def convert_drop_relation(self, rel: spark_relations_pb2.Drop) -> algebra_pb2.Rel:
@@ -1698,14 +1742,16 @@ class SparkSubstraitConverter:
         project = algebra_pb2.ProjectRel(input=input_rel)
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         if rel.columns:
             column_names = [c.unresolved_attribute.unparsed_identifier for c in rel.columns]
         else:
             column_names = rel.column_names
         symbol.output_fields.clear()
-        for field_number, field_name in enumerate(symbol.input_fields):
-            if field_name not in column_names:
-                symbol.output_fields.append(field_name)
+        for field_number, field in enumerate(symbol.input_fields):
+            if field.name not in column_names:
+                symbol.output_fields.append(field)
                 if self._conversion_options.drop_emit_workaround:
                     project.common.emit.output_mapping.append(len(project.expressions))
                     project.expressions.append(field_reference(field_number))
@@ -1720,6 +1766,8 @@ class SparkSubstraitConverter:
         input_rel = self.convert_relation(rel.input)
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         if len(rel.column_names) != len(symbol.input_fields):
             raise ValueError(
                 "column_names does not match the number of input fields at "
@@ -1727,7 +1775,7 @@ class SparkSubstraitConverter:
             )
         symbol.output_fields.clear()
         for field_name in rel.column_names:
-            symbol.output_fields.append(field_name)
+            symbol.output_fields.append(Field(field_name))
         return input_rel
 
     def convert_arrow_to_literal(self, val: pa.Scalar) -> algebra_pb2.Expression.Literal:
@@ -1793,9 +1841,13 @@ class SparkSubstraitConverter:
         """Convert a Spark local relation into a virtual table."""
         read = algebra_pb2.ReadRel(virtual_table=self.convert_arrow_data_to_virtual_table(rel.data))
         schema = self.convert_schema(rel.schema)
+        if not schema:
+            raise ValueError(f'Received an empty schema in plan id {self._current_plan_id}')
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         for field_name in schema.names:
-            symbol.output_fields.append(field_name)
+            symbol.output_fields.append(Field(field_name))
         read.base_schema.CopyFrom(schema)
         read.common.CopyFrom(self.create_common_relation())
         return algebra_pb2.Rel(read=read)
@@ -1805,6 +1857,8 @@ class SparkSubstraitConverter:
         # TODO -- Handle multithreading in the case with a persistent backend.
         plan = self._sql_backend.convert_sql(rel.query)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         for field_name in plan.relations[0].root.names:
             symbol.output_fields.append(field_name)
         # TODO -- Correctly capture all the used functions and extensions.
@@ -1815,7 +1869,7 @@ class SparkSubstraitConverter:
         return plan.relations[0].root.input
 
     def convert_spark_join_type(
-        self, join_type: spark_relations_pb2.Join.JoinType
+            self, join_type: spark_relations_pb2.Join.JoinType
     ) -> algebra_pb2.JoinRel.JoinType:
         """Convert a Spark join type into a Substrait join type."""
         match join_type:
@@ -1833,7 +1887,7 @@ class SparkSubstraitConverter:
                 return algebra_pb2.JoinRel.JOIN_TYPE_ANTI
             case spark_relations_pb2.Join.JOIN_TYPE_LEFT_SEMI:
                 return algebra_pb2.JoinRel.JOIN_TYPE_SEMI
-            case spark_relations_pb2.Join.CROSS:
+            case spark_relations_pb2.Join.JOIN_TYPE_CROSS:
                 raise RuntimeError("Internal error:  cross joins should be handled elsewhere")
             case _:
                 raise ValueError(f"Unexpected join type: {join_type}")
@@ -1868,12 +1922,20 @@ class SparkSubstraitConverter:
         else:
             equal_func = self.lookup_function_by_name("==")
             if rel.using_columns:
-                column = rel.using_columns[0]
-                left_fields = self._symbol_table.get_symbol(rel.left.common.plan_id).output_fields
+                column_name = rel.using_columns[0]
+                left_symbol = self._symbol_table.get_symbol(rel.left.common.plan_id)
+                if not left_symbol:
+                    raise InternalError(
+                        f'Could not find plan id {rel.left.common.plan_id} that we constructed earlier.')
+                left_fields = left_symbol.output_fields
                 left_column_count = len(left_fields)
-                left_column_reference = left_fields.index(column)
-                right_fields = self._symbol_table.get_symbol(rel.right.common.plan_id).output_fields
-                right_column_reference = right_fields.index(column)
+                left_column_reference = _find_reference_number(left_fields, column_name)
+                right_symbol = self._symbol_table.get_symbol(rel.right.common.plan_id)
+                if not right_symbol:
+                    raise InternalError(
+                        f'Could not find plan id {rel.right.common.plan_id} that we constructed earlier.')
+                right_fields = right_symbol.output_fields
+                right_column_reference = _find_reference_number(right_fields, column_name)
                 join.expression.CopyFrom(
                     equal_function(
                         equal_func,
@@ -1884,6 +1946,8 @@ class SparkSubstraitConverter:
 
                 # Avoid emitting the join column twice.
                 symbol = self._symbol_table.get_symbol(self._current_plan_id)
+                if not symbol:
+                    raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
                 if self._conversion_options.join_not_honoring_emit_workaround:
                     project = algebra_pb2.ProjectRel(input=algebra_pb2.Rel(join=join))
                     for column_number in range(len(symbol.output_fields)):
@@ -1898,21 +1962,36 @@ class SparkSubstraitConverter:
                 del symbol.output_fields[right_column_reference + left_column_count]
         return algebra_pb2.Rel(join=join)
 
+    def find_additional_names(self, expr: spark_exprs_pb2.Expression) -> list[str]:
+        if expr.WhichOneof("expr_type") == "alias":
+            current_expr = expr.alias.expr
+        else:
+            current_expr = expr
+        if current_expr.unresolved_function.function_name == "struct":
+            new_names = []
+            for arg in current_expr.unresolved_function.arguments:
+                new_names.append(arg.unresolved_attribute.unparsed_identifier)
+            # TODO -- Handle nested structures.
+            return new_names
+        return []
+
     def convert_project_relation(self, rel: spark_relations_pb2.Project) -> algebra_pb2.Rel:
         """Convert a Spark project relation into a Substrait project relation."""
         input_rel = self.convert_relation(rel.input)
         project = algebra_pb2.ProjectRel(input=input_rel)
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         for field_number, expr in enumerate(rel.expressions):
             if expr.WhichOneof("expr_type") == "unresolved_regex":
                 regex = expr.unresolved_regex.col_name.replace("`", "")
                 matcher = re.compile(regex)
                 found = False
                 for column in symbol.input_fields:
-                    if matcher.match(column):
+                    if matcher.match(column.name):
                         project.expressions.append(
-                            field_reference(symbol.input_fields.index(column))
+                            field_reference(_find_reference_number(symbol.input_fields, column.name))
                         )
                         symbol.generated_fields.append(column)
                         symbol.output_fields.append(column)
@@ -1929,8 +2008,10 @@ class SparkSubstraitConverter:
                 name = expr.unresolved_attribute.unparsed_identifier
             else:
                 name = f"generated_field_{field_number}"
-            symbol.generated_fields.append(name)
-            symbol.output_fields.append(name)
+            projected_symbol = Field(name)
+            projected_symbol.child_names.extend(self.find_additional_names(expr))
+            symbol.generated_fields.append(projected_symbol)
+            symbol.output_fields.append(projected_symbol)
         project.common.CopyFrom(self.create_common_relation())
         symbol.output_fields = symbol.generated_fields
         for field_number in range(len(symbol.output_fields)):
@@ -1938,7 +2019,7 @@ class SparkSubstraitConverter:
         return algebra_pb2.Rel(project=project)
 
     def convert_subquery_alias_relation(
-        self, rel: spark_relations_pb2.SubqueryAlias
+            self, rel: spark_relations_pb2.SubqueryAlias
     ) -> algebra_pb2.Rel:
         """Convert a Spark subquery alias relation into a Substrait relation."""
         raise NotImplementedError("Subquery alias relations are not yet implemented")
@@ -1954,6 +2035,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         aggregate.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         grouping = aggregate.groupings.add()
         for idx, field in enumerate(symbol.input_fields):
             grouping.grouping_expressions.append(field_reference(idx))
@@ -1981,7 +2064,7 @@ class SparkSubstraitConverter:
         return project
 
     def convert_set_operation_relation(
-        self, rel: spark_relations_pb2.SetOperation
+            self, rel: spark_relations_pb2.SetOperation
     ) -> algebra_pb2.Rel:
         """Convert a Spark set operation relation into a Substrait set operation relation."""
         left = self.convert_relation(rel.left_input)
@@ -2035,8 +2118,10 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         filter_rel.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
+        if not symbol:
+            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
         if rel.cols:
-            cols = [symbol.input_fields.index(col) for col in rel.cols]
+            cols = [_find_reference_number(symbol.input_fields, col) for col in rel.cols]
         else:
             cols = range(len(symbol.input_fields))
         min_non_nulls = rel.min_non_nulls if rel.min_non_nulls else len(cols)
@@ -2130,8 +2215,10 @@ class SparkSubstraitConverter:
         if plan.HasField("root"):
             rel_root = algebra_pb2.RelRoot(input=self.convert_relation(plan.root))
             symbol = self._symbol_table.get_symbol(plan.root.common.plan_id)
-            for name in symbol.output_fields:
-                rel_root.names.append(name)
+            if not symbol:
+                raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            for field in symbol.output_fields:
+                rel_root.names.extend(field.output_names())
             result.relations.append(plan_pb2.PlanRel(root=rel_root))
         for uri in sorted(self._function_uris.items(), key=operator.itemgetter(1)):
             result.extension_uris.append(

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -1359,7 +1359,7 @@ class SparkSubstraitConverter:
         rel_grouping_expressions = rel.grouping_expressions
         for idx, grouping in enumerate(rel_grouping_expressions):
             grouping_expression_list.append(self.convert_expression(grouping))
-            symbol.generated_fields.append(self.determine_name_for_grouping(grouping))
+            symbol.generated_fields.append(Field(self.determine_name_for_grouping(grouping)))
             self._top_level_projects.append(field_reference(idx))
 
         match rel.group_type:

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -61,13 +61,13 @@ from gateway.converter.symbol_table import Field, SymbolTable
 
 
 class InternalError(Exception):
-    pass
+    """Raised when there is an internal gateway issue (should not occur)."""
 
 
 class ExpressionProcessingMode(Enum):
     """The mode of processing expressions."""
 
-    # Processing of an expression outside of an aggregate relation.
+    # Processing of an expression outside an aggregate relation.
     NORMAL = 0
     # Processing of a measure at depth 0.
     AGGR_TOP_LEVEL = 1
@@ -145,10 +145,11 @@ class SparkSubstraitConverter:
         """Use the field references using the specified portion of the plan."""
         source_symbol = self._symbol_table.get_symbol(plan_id)
         if not source_symbol:
-            raise InternalError(f'Could not find plan id {plan_id} that we constructed earlier.')
+            raise InternalError(f'Could not find plan id {plan_id} constructed earlier.')
         current_symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not current_symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         original_output_fields = current_symbol.output_fields
         for symbol in source_symbol.output_fields:
             new_symbol = symbol
@@ -161,7 +162,8 @@ class SparkSubstraitConverter:
         """Look up the field name in the current set of field references."""
         current_symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not current_symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         try:
             return _find_reference_number(current_symbol.input_fields, field_name)
         except ValueError:
@@ -895,7 +897,8 @@ class SparkSubstraitConverter:
 
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         if self._conversion_options.use_duckdb_struct_name_behavior:
             for field_name in self.get_primary_names(schema):
                 symbol.output_fields.append(Field(field_name))
@@ -1154,7 +1157,8 @@ class SparkSubstraitConverter:
             schema = self.convert_arrow_schema(arrow_schema)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         for field_name in schema.names:
             symbol.output_fields.append(Field(field_name))
         if self._conversion_options.use_named_table_workaround:
@@ -1226,7 +1230,8 @@ class SparkSubstraitConverter:
             return algebra_pb2.RelCommon(direct=algebra_pb2.RelCommon.Direct())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         emit = algebra_pb2.RelCommon.Emit()
         if emit_overrides:
             for field_number in emit_overrides:
@@ -1310,7 +1315,8 @@ class SparkSubstraitConverter:
         aggregate.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
 
         # Start tracking the parts of the expressions we are interested in.
         self._top_level_projects = []
@@ -1493,7 +1499,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
 
         # Find the length of each column in every row.
         project1 = project_relation(
@@ -1528,7 +1535,8 @@ class SparkSubstraitConverter:
             ],
         )
 
-        def field_header_fragment(fields: list[Field], field_number: int) -> list[algebra_pb2.Expression]:
+        def field_header_fragment(fields: list[Field],
+                                  field_number: int) -> list[algebra_pb2.Expression]:
             return [
                 string_literal("|"),
                 lpad_function(
@@ -1544,7 +1552,8 @@ class SparkSubstraitConverter:
                 repeat_function(repeat_func, "-", field_reference(field_number)),
             ]
 
-        def field_body_fragment(fields: list[Field], field_number: int) -> list[algebra_pb2.Expression]:
+        def field_body_fragment(fields: list[Field],
+                                field_number: int) -> list[algebra_pb2.Expression]:
             return [
                 string_literal("|"),
                 if_then_else_operation(
@@ -1584,7 +1593,8 @@ class SparkSubstraitConverter:
                 concat(
                     concat_func,
                     flatten(
-                        [field_header_fragment(fields, field_number) for field_number in range(len(fields))]
+                        [field_header_fragment(fields, field_number)
+                         for field_number in range(len(fields))]
                     )
                     + [
                         string_literal("|\n"),
@@ -1651,7 +1661,8 @@ class SparkSubstraitConverter:
 
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         symbol.output_fields.clear()
         symbol.output_fields.append(Field("show_string"))
 
@@ -1693,7 +1704,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         proposed_expressions = [field_reference(i) for i in range(len(symbol.input_fields))]
         for alias in rel.aliases:
             if len(alias.name) != 1:
@@ -1721,7 +1733,8 @@ class SparkSubstraitConverter:
         input_rel = self.convert_relation(rel.input)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         self.update_field_references(rel.input.common.plan_id)
         symbol.output_fields.clear()
         if hasattr(rel, "renames"):
@@ -1742,7 +1755,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         if rel.columns:
             column_names = [c.unresolved_attribute.unparsed_identifier for c in rel.columns]
         else:
@@ -1766,7 +1780,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         if len(rel.column_names) != len(symbol.input_fields):
             raise ValueError(
                 "column_names does not match the number of input fields at "
@@ -1844,7 +1859,8 @@ class SparkSubstraitConverter:
             raise ValueError(f'Received an empty schema in plan id {self._current_plan_id}')
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         for field_name in schema.names:
             symbol.output_fields.append(Field(field_name))
         read.base_schema.CopyFrom(schema)
@@ -1857,7 +1873,8 @@ class SparkSubstraitConverter:
         plan = self._sql_backend.convert_sql(rel.query)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         for field_name in plan.relations[0].root.names:
             symbol.output_fields.append(Field(field_name))
         # TODO -- Correctly capture all the used functions and extensions.
@@ -1925,14 +1942,14 @@ class SparkSubstraitConverter:
                 left_symbol = self._symbol_table.get_symbol(rel.left.common.plan_id)
                 if not left_symbol:
                     raise InternalError(
-                        f'Could not find plan id {rel.left.common.plan_id} that we constructed earlier.')
+                        f'Could not find plan id {rel.left.common.plan_id} constructed earlier.')
                 left_fields = left_symbol.output_fields
                 left_column_count = len(left_fields)
                 left_column_reference = _find_reference_number(left_fields, column_name)
                 right_symbol = self._symbol_table.get_symbol(rel.right.common.plan_id)
                 if not right_symbol:
                     raise InternalError(
-                        f'Could not find plan id {rel.right.common.plan_id} that we constructed earlier.')
+                        f'Could not find plan id {rel.right.common.plan_id} constructed earlier.')
                 right_fields = right_symbol.output_fields
                 right_column_reference = _find_reference_number(right_fields, column_name)
                 join.expression.CopyFrom(
@@ -1946,7 +1963,8 @@ class SparkSubstraitConverter:
                 # Avoid emitting the join column twice.
                 symbol = self._symbol_table.get_symbol(self._current_plan_id)
                 if not symbol:
-                    raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+                    raise InternalError(
+                        f'Could not find plan id {self._current_plan_id} constructed earlier.')
                 if self._conversion_options.join_not_honoring_emit_workaround:
                     project = algebra_pb2.ProjectRel(input=algebra_pb2.Rel(join=join))
                     for column_number in range(len(symbol.output_fields)):
@@ -1962,10 +1980,8 @@ class SparkSubstraitConverter:
         return algebra_pb2.Rel(join=join)
 
     def find_additional_names(self, expr: spark_exprs_pb2.Expression) -> list[str]:
-        if expr.WhichOneof("expr_type") == "alias":
-            current_expr = expr.alias.expr
-        else:
-            current_expr = expr
+        """Find any extra names used by this expression."""
+        current_expr = expr.alias.expr if expr.WhichOneof("expr_type") == "alias" else expr
         if current_expr.unresolved_function.function_name == "struct":
             new_names = []
             for arg in current_expr.unresolved_function.arguments:
@@ -1981,7 +1997,8 @@ class SparkSubstraitConverter:
         self.update_field_references(rel.input.common.plan_id)
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         for field_number, expr in enumerate(rel.expressions):
             if expr.WhichOneof("expr_type") == "unresolved_regex":
                 regex = expr.unresolved_regex.col_name.replace("`", "")
@@ -1990,7 +2007,8 @@ class SparkSubstraitConverter:
                 for column in symbol.input_fields:
                     if matcher.match(column.name):
                         project.expressions.append(
-                            field_reference(_find_reference_number(symbol.input_fields, column.name))
+                            field_reference(
+                                _find_reference_number(symbol.input_fields, column.name))
                         )
                         symbol.generated_fields.append(column)
                         symbol.output_fields.append(column)
@@ -2035,7 +2053,8 @@ class SparkSubstraitConverter:
         aggregate.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         grouping = aggregate.groupings.add()
         for idx, field in enumerate(symbol.input_fields):
             grouping.grouping_expressions.append(field_reference(idx))
@@ -2118,7 +2137,8 @@ class SparkSubstraitConverter:
         filter_rel.common.CopyFrom(self.create_common_relation())
         symbol = self._symbol_table.get_symbol(self._current_plan_id)
         if not symbol:
-            raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+            raise InternalError(
+                f'Could not find plan id {self._current_plan_id} constructed earlier.')
         if rel.cols:
             cols = [_find_reference_number(symbol.input_fields, col) for col in rel.cols]
         else:
@@ -2215,7 +2235,8 @@ class SparkSubstraitConverter:
             rel_root = algebra_pb2.RelRoot(input=self.convert_relation(plan.root))
             symbol = self._symbol_table.get_symbol(plan.root.common.plan_id)
             if not symbol:
-                raise InternalError(f'Could not find plan id {self._current_plan_id} that we constructed earlier.')
+                raise InternalError(
+                    f'Could not find plan id {self._current_plan_id} constructed earlier.')
             for field in symbol.output_fields:
                 rel_root.names.extend(field.output_names())
             result.relations.append(plan_pb2.PlanRel(root=rel_root))

--- a/src/gateway/converter/spark_to_substrait.py
+++ b/src/gateway/converter/spark_to_substrait.py
@@ -764,8 +764,15 @@ class SparkSubstraitConverter:
                 value=self.convert_unresolved_attribute(extract.child.unresolved_attribute)
             )
         )
+        # MEGAHACK -- Fix this to be relative to the struct value we found above.
+        field_ref = self.find_field_by_name(extract.extraction.literal.string)
+        if field_ref is None:
+            raise ValueError(
+                f"could not locate field named {extract.extraction.literal.string} in plan id "
+                f"{self._current_plan_id}"
+            )
         func.arguments.append(
-            algebra_pb2.FunctionArgument(value=string_literal(extract.extraction.literal.string))
+            algebra_pb2.FunctionArgument(value=integer_literal(field_ref+1))
         )
         return algebra_pb2.Expression(scalar_function=func)
 

--- a/src/gateway/converter/symbol_table.py
+++ b/src/gateway/converter/symbol_table.py
@@ -24,7 +24,7 @@ class Field:
         return new_field
 
     def output_names(self) -> list[str]:
-        """Return all of the names used by this field (including subtypes)."""
+        """Return all the names used by this field (including subtypes)."""
         return [self.name, *self.child_names]
 
 

--- a/src/gateway/converter/symbol_table.py
+++ b/src/gateway/converter/symbol_table.py
@@ -2,7 +2,6 @@
 """Routines to convert SparkConnect plans to Substrait plans."""
 
 import dataclasses
-from typing import Self
 
 
 @dataclasses.dataclass
@@ -18,7 +17,7 @@ class Field:
         self.name = name
         self.child_names = child_names or []
 
-    def alias(self, name: str) -> Self:
+    def alias(self, name: str):
         """Create a copy with an alternate name."""
         new_field = Field(name)
         new_field.child_names = self.child_names

--- a/src/gateway/converter/symbol_table.py
+++ b/src/gateway/converter/symbol_table.py
@@ -11,14 +11,14 @@ class PlanMetadata:
     plan_id: int
     type: str | None
     parent_plan_id: int | None
-    input_fields: list[str]  # And maybe type
+    input_fields: list[str]  # And maybe type with additional names
     generated_fields: list[str]
     output_fields: list[str]
 
     def __init__(self, plan_id: int):
         """Create the PlanMetadata structure."""
         self.plan_id = plan_id
-        self.symbol_type = None
+        self.symbol_type = None  # Useful when debugging.
         self.parent_plan_id = None
         self.input_fields = []
         self.generated_fields = []

--- a/src/gateway/converter/symbol_table.py
+++ b/src/gateway/converter/symbol_table.py
@@ -2,6 +2,7 @@
 """Routines to convert SparkConnect plans to Substrait plans."""
 
 import dataclasses
+from typing import Self
 
 
 @dataclasses.dataclass
@@ -17,13 +18,15 @@ class Field:
         self.name = name
         self.child_names = child_names or []
 
-    def alias(self, name: str):
+    def alias(self, name: str) -> Self:
+        """Create a copy with an alternate name."""
         new_field = Field(name)
         new_field.child_names = self.child_names
         return new_field
 
     def output_names(self) -> list[str]:
-        return [self.name] + self.child_names
+        """Return all of the names used by this field (including subtypes)."""
+        return [self.name, *self.child_names]
 
 
 @dataclasses.dataclass

--- a/src/gateway/converter/symbol_table.py
+++ b/src/gateway/converter/symbol_table.py
@@ -5,15 +5,37 @@ import dataclasses
 
 
 @dataclasses.dataclass
+class Field:
+    """Tracks the names used by a field used as the input or output of a relation."""
+
+    name: str
+    # TODO -- Also track the field's type.
+    child_names: list[str]
+
+    def __init__(self, name: str, child_names=None):
+        """Create the Field structure."""
+        self.name = name
+        self.child_names = child_names or []
+
+    def alias(self, name: str):
+        new_field = Field(name)
+        new_field.child_names = self.child_names
+        return new_field
+
+    def output_names(self) -> list[str]:
+        return [self.name] + self.child_names
+
+
+@dataclasses.dataclass
 class PlanMetadata:
     """Tracks various information about a specific plan id."""
 
     plan_id: int
-    type: str | None
+    symbol_type: str | None
     parent_plan_id: int | None
-    input_fields: list[str]  # And maybe type with additional names
-    generated_fields: list[str]
-    output_fields: list[str]
+    input_fields: list[Field]
+    generated_fields: list[Field]
+    output_fields: list[Field]
 
     def __init__(self, plan_id: int):
         """Create the PlanMetadata structure."""

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -386,7 +386,6 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
                 for pair in request.operation.set.pairs:
                     if pair.key == "spark-substrait-gateway.backend":
                         # Set the server backend for all connections (including ongoing ones).
-                        need_reset = False
                         match pair.value:
                             case "arrow":
                                 if (self._backend is not None and

--- a/src/gateway/server.py
+++ b/src/gateway/server.py
@@ -386,6 +386,7 @@ class SparkConnectService(pb2_grpc.SparkConnectServiceServicer):
                 for pair in request.operation.set.pairs:
                     if pair.key == "spark-substrait-gateway.backend":
                         # Set the server backend for all connections (including ongoing ones).
+                        need_reset = False
                         match pair.value:
                             case "arrow":
                                 if (self._backend is not None and

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -160,6 +160,9 @@ def mark_dataframe_tests_as_xfail(request):
     if source == "gateway-over-duckdb" and originalname == "test_cube":
         pytest.skip(reason="cube aggregation not yet implemented in DuckDB")
 
+    if source == "gateway-over-duckdb" and originalname in ["test_column_getfield",
+                                                                "test_struct_and_getfield"]:
+        pytest.skip(reason="fully named structs not yet tracked in gateway")
     if source == "gateway-over-datafusion" and originalname in ["test_struct",
                                                                 "test_struct_and_getfield"]:
         pytest.skip(reason="nested expressions not supported")

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -2850,7 +2850,6 @@ class TestDataFrameDecisionSupport:
 class TestDataFrameComplexDatastructures:
     """Tests the use of complex datastructures in the dataframe side of SparkConnect."""
 
-    @pytest.mark.interesting
     def test_struct(self, register_tpch_dataset, spark_session, caplog):
         expected = [
             Row(test_struct=Row(c_custkey=1, c_name='Customer#000000001')),
@@ -2865,7 +2864,6 @@ class TestDataFrameComplexDatastructures:
 
         assertDataFrameEqual(outcome, expected)
 
-    @pytest.mark.interesting
     def test_struct_and_getfield(self, register_tpch_dataset, spark_session, caplog):
         expected = [
             Row(result=1),

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -57,12 +57,13 @@ from pyspark.sql.functions import (
     rtrim,
     sqrt,
     startswith,
+    struct,
     substr,
     substring,
     trim,
     try_sum,
     ucase,
-    upper, struct,
+    upper,
 )
 from pyspark.sql.types import DoubleType, IntegerType, StringType, StructField, StructType
 from pyspark.sql.window import Window

--- a/src/gateway/tests/test_dataframe_api.py
+++ b/src/gateway/tests/test_dataframe_api.py
@@ -160,6 +160,10 @@ def mark_dataframe_tests_as_xfail(request):
     if source == "gateway-over-duckdb" and originalname == "test_cube":
         pytest.skip(reason="cube aggregation not yet implemented in DuckDB")
 
+    if source == "gateway-over-datafusion" and originalname in ["test_struct",
+                                                                "test_struct_and_getfield"]:
+        pytest.skip(reason="nested expressions not supported")
+
 
 # ruff: noqa: E712
 class TestDataFrameAPI:


### PR DESCRIPTION
Adds the capability to create structs one level deep using the Spark struct() data frame API.

To assist with this functionality the field handling data structure has been upgraded from a
string reference into a full type (Field) allowing for tracking of additional names today and
precise type tracking in the future. 

Future PRs will add arbitrary type adding and will make getField() work on structures.